### PR TITLE
Feature/#11 bot interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/virtual_ai_pa
 # Auth
 SECRET_KEY=CHANGE_ME_TO_A_SECURE_RANDOM_KEY
 
+# Admin seed (created on first startup)
+ADMIN_USERNAME=admin
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=changeme
+
 # Frontend (used when constructing password-reset links)
 FRONTEND_URL=http://localhost:8080
 

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,4 +1,9 @@
 # Virtual AI Patient Bot
 
-Telegram bot service for Virtual AI Patient.
+Telegram bot interface for Virtual AI Patient.
 
+- **Framework**: aiogram 3.x
+- **Language**: Python 3.14
+
+Users authenticate automatically via their Telegram identity on `/start` — no password input required.
+Available commands: `/start`, `/help`, `/cases`, `/order_test`, `/diagnosis`, `/treatment`, `/debrief`, `/history`.

--- a/bot/backend_client.py
+++ b/bot/backend_client.py
@@ -1,0 +1,76 @@
+import hashlib
+from typing import Any, Dict
+
+import httpx
+
+
+class BackendClient:
+    def __init__(self, base_url: str, secret_salt: str) -> None:
+        self._base_url = base_url
+        self._salt = secret_salt
+
+    def _tg_password(self, telegram_user_id: int) -> str:
+        """Derive a stable, secret password for a Telegram user.
+
+        Uses HMAC-like SHA-256 with the bot token as salt so the same
+        password is always produced for the same user_id without storing it.
+        """
+        raw = f"{self._salt}:{telegram_user_id}"
+        return hashlib.sha256(raw.encode()).hexdigest()[:32]
+
+    async def login(self, username: str, password: str) -> str:
+        """Authenticate with backend using form data. Returns access_token."""
+        async with httpx.AsyncClient(base_url=self._base_url, timeout=10.0) as client:
+            response = await client.post(
+                "/auth/login",
+                data={"username": username, "password": password},
+            )
+            response.raise_for_status()
+            data: Dict[str, Any] = response.json()
+            token = data.get("access_token")
+            if not isinstance(token, str):
+                raise RuntimeError("Backend did not return access_token")
+            return token
+
+    async def signup(
+        self, username: str, email: str, password: str
+    ) -> Dict[str, Any]:
+        """Register a new user. Returns UserResponse dict."""
+        async with httpx.AsyncClient(base_url=self._base_url, timeout=10.0) as client:
+            response = await client.post(
+                "/auth/signup",
+                json={"username": username, "email": email, "password": password},
+            )
+            response.raise_for_status()
+            result: Dict[str, Any] = response.json()
+            return result
+
+    async def auto_register_and_login(self, telegram_user_id: int) -> str:
+        """Ensure a backend account exists for this Telegram user and return access_token.
+
+        Uses a deterministic username and password derived from telegram_user_id
+        so re-login is possible even after the in-memory token is lost.
+        """
+        username = f"tg_{telegram_user_id}"
+        email = f"tg_{telegram_user_id}@bot.internal"
+        password = self._tg_password(telegram_user_id)
+
+        try:
+            await self.signup(username, email, password)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 409:
+                raise
+            # 409 = already registered, proceed to login
+
+        return await self.login(username, password)
+
+    async def verify(self, token: str) -> Dict[str, Any]:
+        """Verify token and return UserResponse dict (id, username, email, role)."""
+        async with httpx.AsyncClient(base_url=self._base_url, timeout=10.0) as client:
+            response = await client.get(
+                "/auth/verify",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            result: Dict[str, Any] = response.json()
+            return result

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -14,8 +14,8 @@ async def login_to_backend(settings: Settings) -> str:
         base_url=settings.backend_base_url, timeout=10.0
     ) as client:
         response = await client.post(
-            "/login",
-            json={
+            "/auth/login",
+            data={
                 "username": settings.backend_username,
                 "password": settings.backend_password,
             },
@@ -33,7 +33,7 @@ async def fetch_current_user(settings: Settings, token: str) -> Dict[str, Any]:
         base_url=settings.backend_base_url, timeout=10.0
     ) as client:
         response = await client.get(
-            "/me",
+            "/auth/verify",
             headers={"Authorization": f"Bearer {token}"},
         )
         response.raise_for_status()

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -8,6 +8,7 @@ from aiogram.fsm.storage.memory import MemoryStorage
 
 from backend_client import BackendClient
 from bot_config import Settings
+from middleware import ThrottlingMiddleware
 from routers import auth, menu
 
 logging.basicConfig(level=logging.INFO)
@@ -32,6 +33,8 @@ async def main() -> None:
     bot = Bot(token=settings.telegram_token)
     storage = MemoryStorage()
     dp = Dispatcher(storage=storage)
+
+    dp.message.middleware(ThrottlingMiddleware(rate_limit=1.0))
 
     dp.include_router(auth.router)
     dp.include_router(menu.router)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,15 +1,14 @@
 import asyncio
 import logging
-from contextlib import asynccontextmanager
-from typing import AsyncGenerator
 
 from aiogram import Bot, Dispatcher
 from aiogram.fsm.storage.memory import MemoryStorage
+from aiogram.types import BotCommand
 
 from backend_client import BackendClient
 from bot_config import Settings
 from middleware import ThrottlingMiddleware
-from routers import auth, menu
+from routers import auth, errors, menu
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -36,8 +35,28 @@ async def main() -> None:
 
     dp.message.middleware(ThrottlingMiddleware(rate_limit=1.0))
 
+    dp.include_router(errors.router)
     dp.include_router(auth.router)
     dp.include_router(menu.router)
+
+    webhook_info = await bot.get_webhook_info()
+    if webhook_info.url:
+        logger.warning("Active webhook found: %s — deleting it", webhook_info.url)
+        await bot.delete_webhook(drop_pending_updates=False)
+    else:
+        logger.info("No active webhook, proceeding with polling")
+
+    await bot.set_my_commands([
+        BotCommand(command="start",      description="Главное меню и вход"),
+        BotCommand(command="cases",      description="Список доступных кейсов"),
+        BotCommand(command="order_test", description="Заказать медицинский тест"),
+        BotCommand(command="diagnosis",  description="Отправить дифференциальный диагноз"),
+        BotCommand(command="treatment",  description="Отправить план лечения"),
+        BotCommand(command="debrief",    description="Получить разбор завершённого кейса"),
+        BotCommand(command="history",    description="История прошлых сессий"),
+        BotCommand(command="help",       description="Список всех команд"),
+    ])
+    logger.info("Bot commands registered with Telegram")
 
     await dp.start_polling(bot)
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,67 +1,40 @@
 import asyncio
-from typing import Any, Dict, cast
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 
-import httpx
 from aiogram import Bot, Dispatcher
-from aiogram.filters import CommandStart
-from aiogram.types import Message
+from aiogram.fsm.storage.memory import MemoryStorage
 
+from backend_client import BackendClient
 from bot_config import Settings
+from routers import auth, menu
 
-
-async def login_to_backend(settings: Settings) -> str:
-    async with httpx.AsyncClient(
-        base_url=settings.backend_base_url, timeout=10.0
-    ) as client:
-        response = await client.post(
-            "/auth/login",
-            data={
-                "username": settings.backend_username,
-                "password": settings.backend_password,
-            },
-        )
-        response.raise_for_status()
-        data = cast(Dict[str, Any], response.json())
-        token = data.get("access_token")
-        if not isinstance(token, str):
-            raise RuntimeError("Backend did not return access_token")
-        return token
-
-
-async def fetch_current_user(settings: Settings, token: str) -> Dict[str, Any]:
-    async with httpx.AsyncClient(
-        base_url=settings.backend_base_url, timeout=10.0
-    ) as client:
-        response = await client.get(
-            "/auth/verify",
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        response.raise_for_status()
-        return cast(Dict[str, Any], response.json())
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
     settings = Settings.from_env()
+    client = BackendClient(
+        base_url=settings.backend_base_url,
+        secret_salt=settings.telegram_token,
+    )
+
+    # Health-check: verify the backend service account is reachable
+    try:
+        token = await client.login(settings.backend_username, settings.backend_password)
+        user = await client.verify(token)
+        logger.info("Backend connection verified. Service account: %s", user.get("username"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Backend health-check failed: %s", exc)
 
     bot = Bot(token=settings.telegram_token)
-    dp = Dispatcher()
+    storage = MemoryStorage()
+    dp = Dispatcher(storage=storage)
 
-    @dp.message(CommandStart())
-    async def handle_start(message: Message) -> None:  # noqa: D401
-        """
-        /start handler that checks backend auth.
-        """
-        await message.answer("Logging in to backend...")
-
-        try:
-            token = await login_to_backend(settings)
-            user = await fetch_current_user(settings, token)
-        except Exception as exc:  # noqa: BLE001
-            await message.answer(f"Backend auth failed: {exc}")
-            return
-
-        username = user.get("username", "unknown")
-        await message.answer(f"Hello, {username}! Backend auth is working.")
+    dp.include_router(auth.router)
+    dp.include_router(menu.router)
 
     await dp.start_polling(bot)
 

--- a/bot/middleware.py
+++ b/bot/middleware.py
@@ -1,0 +1,47 @@
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from aiogram import BaseMiddleware
+from aiogram.types import Message, TelegramObject
+
+
+class ThrottlingMiddleware(BaseMiddleware):
+    """Simple per-user rate limiter.
+
+    Rejects messages that arrive faster than `rate_limit` seconds apart
+    for the same user. Sends a single warning and then silently drops
+    subsequent messages until the cooldown expires.
+    """
+
+    def __init__(self, rate_limit: float = 1.0) -> None:
+        self._rate_limit = rate_limit
+        self._last_called: dict[int, float] = {}
+        self._warned: set[int] = set()
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        if not isinstance(event, Message) or event.from_user is None:
+            return await handler(event, data)
+
+        user_id = event.from_user.id
+        now = time.monotonic()
+        last = self._last_called.get(user_id, 0.0)
+        delta = now - last
+
+        if delta < self._rate_limit:
+            if user_id not in self._warned:
+                self._warned.add(user_id)
+                await event.answer(
+                    f"Пожалуйста, не отправляйте сообщения так быстро. "
+                    f"Подождите {self._rate_limit:.0f} сек."
+                )
+            return None
+
+        self._last_called[user_id] = now
+        self._warned.discard(user_id)
+        return await handler(event, data)

--- a/bot/routers/auth.py
+++ b/bot/routers/auth.py
@@ -139,7 +139,6 @@ async def handle_session_callback(callback: CallbackQuery, state: FSMContext) ->
         )
     elif action == "exit":
         await state.clear()
-        data = await state.get_data()
         role = "learner"
         await callback.message.answer(
             "Кейс завершён. Главное меню:",

--- a/bot/routers/auth.py
+++ b/bot/routers/auth.py
@@ -14,6 +14,7 @@ from aiogram.types import (
 
 from backend_client import BackendClient
 from bot_config import Settings
+from routers.menu import HELP_TEXT
 from states import CaseStates
 
 router = Router()
@@ -79,13 +80,18 @@ async def _get_or_refresh_token(
 
 @router.message(CommandStart())
 async def handle_start(message: Message, state: FSMContext) -> None:
+    if message.from_user is None:
+        logger.warning("Received /start with no from_user, ignoring")
+        return
+
+    logger.info("Received /start from user %s", message.from_user.id)
+
     settings = Settings.from_env()
     client = BackendClient(
         base_url=settings.backend_base_url,
         secret_salt=settings.telegram_token,
     )
 
-    assert message.from_user is not None
     telegram_user_id = message.from_user.id
     first_name = message.from_user.first_name or "Пользователь"
 
@@ -147,7 +153,7 @@ async def handle_menu_callback(callback: CallbackQuery) -> None:
     stubs = {
         "cases": "Список кейсов — скоро будет доступно.",
         "history": "История сессий — скоро будет доступно.",
-        "help": "Доступные команды:\n/start — главное меню\n/cases — список кейсов\n/history — история\n/help — помощь",
+        "help": HELP_TEXT,
         "create_case": "Создание кейсов — скоро будет доступно.",
         "students": "Список студентов — скоро будет доступно.",
         "stats": "Статистика — скоро будет доступно.",

--- a/bot/routers/auth.py
+++ b/bot/routers/auth.py
@@ -14,6 +14,7 @@ from aiogram.types import (
 
 from backend_client import BackendClient
 from bot_config import Settings
+from states import CaseStates
 
 router = Router()
 logger = logging.getLogger(__name__)
@@ -98,6 +99,20 @@ async def handle_start(message: Message, state: FSMContext) -> None:
     role: str = user_info.get("role", "learner")
     username: str = user_info.get("username", first_name)
 
+    # Session persistence: offer to resume if user was in an active case
+    current_state = await state.get_state()
+    if current_state == CaseStates.in_conversation.state:
+        resume_kb = InlineKeyboardMarkup(inline_keyboard=[
+            [InlineKeyboardButton(text="Продолжить кейс", callback_data="session:resume"),
+             InlineKeyboardButton(text="Выйти из кейса", callback_data="session:exit")],
+        ])
+        await message.answer(
+            f"С возвращением, {first_name}! У вас есть незавершённый кейс.\n"
+            "Хотите продолжить?",
+            reply_markup=resume_kb,
+        )
+        return
+
     await message.answer(
         f"Добро пожаловать, {first_name}!\n"
         f"Вы вошли как <b>{username}</b> (роль: {role}).",
@@ -105,6 +120,25 @@ async def handle_start(message: Message, state: FSMContext) -> None:
         reply_markup=_menu_for_role(role),
     )
     logger.info("User %s authenticated (role=%s)", telegram_user_id, role)
+
+
+@router.callback_query(lambda c: c.data and c.data.startswith("session:"))
+async def handle_session_callback(callback: CallbackQuery, state: FSMContext) -> None:
+    action = (callback.data or "").split(":")[1]
+    await callback.answer()
+    assert isinstance(callback.message, Message)
+    if action == "resume":
+        await callback.message.answer(
+            "Возвращаемся к кейсу... (функция будет доступна после реализации модуля кейсов)"
+        )
+    elif action == "exit":
+        await state.clear()
+        data = await state.get_data()
+        role = "learner"
+        await callback.message.answer(
+            "Кейс завершён. Главное меню:",
+            reply_markup=_menu_for_role(role),
+        )
 
 
 @router.callback_query(lambda c: c.data and c.data.startswith("menu:"))

--- a/bot/routers/auth.py
+++ b/bot/routers/auth.py
@@ -1,0 +1,125 @@
+import logging
+from typing import Any, Dict
+
+import httpx
+from aiogram import Router
+from aiogram.filters import CommandStart
+from aiogram.fsm.context import FSMContext
+from aiogram.types import (
+    CallbackQuery,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+)
+
+from backend_client import BackendClient
+from bot_config import Settings
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+_TOKEN_KEY = "access_token"
+
+
+def _learner_menu() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="Кейсы", callback_data="menu:cases"),
+         InlineKeyboardButton(text="История", callback_data="menu:history")],
+        [InlineKeyboardButton(text="Помощь", callback_data="menu:help")],
+    ])
+
+
+def _educator_menu() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="Кейсы", callback_data="menu:cases"),
+         InlineKeyboardButton(text="Создать кейс", callback_data="menu:create_case")],
+        [InlineKeyboardButton(text="Студенты", callback_data="menu:students"),
+         InlineKeyboardButton(text="Помощь", callback_data="menu:help")],
+    ])
+
+
+def _admin_menu() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="Статистика", callback_data="menu:stats"),
+         InlineKeyboardButton(text="Пользователи", callback_data="menu:users")],
+        [InlineKeyboardButton(text="Помощь", callback_data="menu:help")],
+    ])
+
+
+def _menu_for_role(role: str) -> InlineKeyboardMarkup:
+    if role == "educator":
+        return _educator_menu()
+    if role == "admin":
+        return _admin_menu()
+    return _learner_menu()
+
+
+async def _get_or_refresh_token(
+    state: FSMContext,
+    client: BackendClient,
+    telegram_user_id: int,
+) -> tuple[str, Dict[str, Any]]:
+    """Return (access_token, user_info). Re-registers/re-logins if token is missing or expired."""
+    data = await state.get_data()
+    token: str | None = data.get(_TOKEN_KEY)
+
+    if token:
+        try:
+            user_info = await client.verify(token)
+            return token, user_info
+        except httpx.HTTPStatusError:
+            pass  # token expired or invalid — fall through to re-login
+
+    token = await client.auto_register_and_login(telegram_user_id)
+    await state.update_data({_TOKEN_KEY: token})
+    user_info = await client.verify(token)
+    return token, user_info
+
+
+@router.message(CommandStart())
+async def handle_start(message: Message, state: FSMContext) -> None:
+    settings = Settings.from_env()
+    client = BackendClient(
+        base_url=settings.backend_base_url,
+        secret_salt=settings.telegram_token,
+    )
+
+    assert message.from_user is not None
+    telegram_user_id = message.from_user.id
+    first_name = message.from_user.first_name or "Пользователь"
+
+    try:
+        token, user_info = await _get_or_refresh_token(state, client, telegram_user_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Auth failed for user %s: %s", telegram_user_id, exc)
+        await message.answer("Не удалось подключиться к серверу. Попробуйте позже.")
+        return
+
+    role: str = user_info.get("role", "learner")
+    username: str = user_info.get("username", first_name)
+
+    await message.answer(
+        f"Добро пожаловать, {first_name}!\n"
+        f"Вы вошли как <b>{username}</b> (роль: {role}).",
+        parse_mode="HTML",
+        reply_markup=_menu_for_role(role),
+    )
+    logger.info("User %s authenticated (role=%s)", telegram_user_id, role)
+
+
+@router.callback_query(lambda c: c.data and c.data.startswith("menu:"))
+async def handle_menu_callback(callback: CallbackQuery) -> None:
+    action = (callback.data or "").split(":")[1]
+    stubs = {
+        "cases": "Список кейсов — скоро будет доступно.",
+        "history": "История сессий — скоро будет доступно.",
+        "help": "Доступные команды:\n/start — главное меню\n/cases — список кейсов\n/history — история\n/help — помощь",
+        "create_case": "Создание кейсов — скоро будет доступно.",
+        "students": "Список студентов — скоро будет доступно.",
+        "stats": "Статистика — скоро будет доступно.",
+        "users": "Управление пользователями — скоро будет доступно.",
+    }
+    text = stubs.get(action, "Неизвестное действие.")
+    await callback.answer()
+    assert isinstance(callback.message, Message)
+    await callback.message.answer(text)

--- a/bot/routers/errors.py
+++ b/bot/routers/errors.py
@@ -1,0 +1,13 @@
+import logging
+
+from aiogram import Router
+from aiogram.types import ErrorEvent
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+
+@router.errors()
+async def handle_error(event: ErrorEvent) -> bool:
+    logger.exception("Unhandled exception in handler: %s", event.exception)
+    return True

--- a/bot/routers/menu.py
+++ b/bot/routers/menu.py
@@ -1,0 +1,54 @@
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+router = Router()
+
+_COMING_SOON = "Скоро будет доступно."
+
+_HELP_TEXT = (
+    "Доступные команды:\n\n"
+    "/start — главное меню и вход\n"
+    "/cases — список доступных кейсов\n"
+    "/order_test — заказать медицинский тест\n"
+    "/diagnosis — отправить дифференциальный диагноз\n"
+    "/treatment — отправить план лечения\n"
+    "/debrief — получить разбор завершённого кейса\n"
+    "/history — история прошлых сессий\n"
+    "/help — эта справка"
+)
+
+
+@router.message(Command("help"))
+async def cmd_help(message: Message) -> None:
+    await message.answer(_HELP_TEXT)
+
+
+@router.message(Command("cases"))
+async def cmd_cases(message: Message) -> None:
+    await message.answer(_COMING_SOON)
+
+
+@router.message(Command("order_test"))
+async def cmd_order_test(message: Message) -> None:
+    await message.answer(_COMING_SOON)
+
+
+@router.message(Command("diagnosis"))
+async def cmd_diagnosis(message: Message) -> None:
+    await message.answer(_COMING_SOON)
+
+
+@router.message(Command("treatment"))
+async def cmd_treatment(message: Message) -> None:
+    await message.answer(_COMING_SOON)
+
+
+@router.message(Command("debrief"))
+async def cmd_debrief(message: Message) -> None:
+    await message.answer(_COMING_SOON)
+
+
+@router.message(Command("history"))
+async def cmd_history(message: Message) -> None:
+    await message.answer(_COMING_SOON)

--- a/bot/routers/menu.py
+++ b/bot/routers/menu.py
@@ -6,7 +6,7 @@ router = Router()
 
 _COMING_SOON = "Скоро будет доступно."
 
-_HELP_TEXT = (
+HELP_TEXT = (
     "Доступные команды:\n\n"
     "/start — главное меню и вход\n"
     "/cases — список доступных кейсов\n"
@@ -21,7 +21,7 @@ _HELP_TEXT = (
 
 @router.message(Command("help"))
 async def cmd_help(message: Message) -> None:
-    await message.answer(_HELP_TEXT)
+    await message.answer(HELP_TEXT)
 
 
 @router.message(Command("cases"))
@@ -52,3 +52,10 @@ async def cmd_debrief(message: Message) -> None:
 @router.message(Command("history"))
 async def cmd_history(message: Message) -> None:
     await message.answer(_COMING_SOON)
+
+
+@router.message()
+async def cmd_unknown(message: Message) -> None:
+    await message.answer(
+        "Не понимаю эту команду. Напишите /help для списка доступных команд."
+    )

--- a/bot/states.py
+++ b/bot/states.py
@@ -1,0 +1,11 @@
+from aiogram.fsm.state import State, StatesGroup
+
+
+class CaseStates(StatesGroup):
+    """FSM states for the clinical case workflow (placeholder for future use)."""
+
+    selecting_case = State()
+    in_conversation = State()
+    ordering_test = State()
+    submitting_diagnosis = State()
+    submitting_treatment = State()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,11 +59,10 @@ services:
     container_name: virtual-ai-patient-bot
     depends_on:
       - backend
+    env_file:
+      - .env
     environment:
-      TELEGRAM_BOT_TOKEN: "REPLACE_WITH_REAL_TOKEN"
       BACKEND_BASE_URL: "http://backend:8000"
-      BACKEND_USERNAME: "admin"
-      BACKEND_PASSWORD: "password"
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Description

This PR implements the Telegram Bot Interface (Epic #11) — a standalone bot service
built with aiogram 3.x that lets users authenticate automatically via their Telegram
identity and access the Virtual AI Patient platform from any Telegram client.
The bot integrates with the backend auth API and includes rate limiting, session
persistence, role-based menus, and a complete command set.

## Related Issue

- Related to #11

## Subtasks Checklist

- [x] Bot service setup (aiogram 3, Dockerfile, docker-compose integration)
- [x] Automatic authentication via Telegram ID — no password input required
- [x] Role-based inline menus (learner / educator / admin)
- [x] All 8 commands registered with Telegram API (`set_my_commands`)
- [x] Session persistence — `/start` detects active case and offers resume or exit
- [x] Rate limiting (ThrottlingMiddleware — 1 msg/sec per user)
- [x] Error handling router — unhandled exceptions are logged
- [x] Webhook conflict detection and cleanup on startup
- [x] Unknown message/command catch-all handler
- [x] `docker-compose.yml` — loads env from `.env`, removed hardcoded token
- [x] User guide (`bot/README.md`)
- [ ] Case selection with real data — blocked on backend case listing API
- [ ] Conversation with virtual patient — blocked on AI/conversation backend
- [ ] Test ordering, diagnosis/treatment submission, debrief — blocked on backend epics

## Verification of Acceptance Criteria

- [x] **Bot authentication flow** — send `/start` to `@ai_patient_bot`; bot replies
  with greeting and role-based menu
- [x] **Session persistence** — `/start` shows resume/exit prompt if user has active case
- [x] **Error handling and user guidance** — unrecognized text returns
  "Не понимаю эту команду. Напишите /help"
- [x] **Rate limiting and anti-spam** — >1 msg/sec triggers warning,
  subsequent messages dropped until cooldown
- [x] **User guide for bot commands** — `bot/README.md` + "/" menu visible in Telegram
- [ ] **Case selection, conversation, test ordering, form submission, debrief**
  — blocked on backend epics

## Screenshots

### `/start` — authentication and role-based menu
<img width="502" height="222" alt="image" src="https://github.com/user-attachments/assets/a909f4f7-bda8-477a-9079-acab91ef9b0e" />


### Telegram "/" command menu
<img width="647" height="274" alt="image" src="https://github.com/user-attachments/assets/55974db5-7325-4c74-a02c-d5d301f729b3" />


### Docker logs — successful auth flow
<img width="1032" height="257" alt="image" src="https://github.com/user-attachments/assets/89b72aa6-f984-41fa-97bc-883222656679" />

## PR Checklist

- [x] I have linked the related issue.
- [x] My code follows the project's style guidelines.
- [ ] I have added or updated tests to cover my changes.
- [x] All new and existing tests pass.