### PR TITLE
Feature/cases get put

### DIFF
--- a/backend/cases/router.py
+++ b/backend/cases/router.py
@@ -1,7 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from cases.repository import CaseRepository
-from cases.request import CreateCaseRequest
+from cases.request import CreateCaseRequest, UpdateCaseRequest
 from cases.response import CaseResponse
 from cases.service import CaseService
 from dependencies import get_current_user, get_db
@@ -26,6 +28,44 @@ def _require_educator(current_user: User = Depends(get_current_user)) -> User:
             status_code=status.HTTP_403_FORBIDDEN, detail="Educators only"
         )
     return current_user
+
+
+@router.get("", response_model=list[CaseResponse])
+async def list_cases(
+    case_status: Annotated[
+        Literal["draft", "review", "published"] | None,
+        Query(
+            alias="status",
+            description="Educators: filter by workflow status",
+        ),
+    ] = None,
+    current_user: User = Depends(get_current_user),
+    service: CaseService = Depends(get_case_service),
+) -> list[CaseResponse]:
+    if current_user.role == "learner":
+        return await service.list_cases(status=None, published_only=True)
+    if current_user.role == "educator":
+        return await service.list_cases(
+            status=case_status, published_only=False
+        )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+    )
+
+
+@router.put("/{id}", response_model=CaseResponse)
+async def update_case(
+    id: str,
+    data: UpdateCaseRequest,
+    current_user: User = Depends(_require_educator),
+    service: CaseService = Depends(get_case_service),
+) -> CaseResponse:
+    case = await service.get_by_id(id)
+    if case is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Case not found"
+        )
+    return await service.update(case, data)
 
 
 @router.post("", response_model=CaseResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/tests/test_cases.py
+++ b/backend/tests/test_cases.py
@@ -153,3 +153,151 @@ def test_create_case_scoring_weights_not_summing_to_one(
     payload["scoring"]["weight_diagnosis"] = 0.99
     r = client.post("/cases", json=payload, headers=educator_headers)
     assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /cases
+# ---------------------------------------------------------------------------
+
+
+def _minimal_case_alt(case_id: str) -> dict[str, Any]:
+    payload = _minimal_case()
+    payload["case_id"] = case_id
+    return payload
+
+
+def test_list_cases_learner_sees_only_published(
+    client: TestClient,
+    educator_headers: dict[str, str],
+    learner_headers: dict[str, str],
+) -> None:
+    client.post("/cases", json=_minimal_case(), headers=educator_headers)
+    r2 = client.post(
+        "/cases", json=_minimal_case_alt("chest_pain_002"), headers=educator_headers
+    )
+    assert r2.status_code == 201
+    pub_id = r2.json()["id"]
+    up = client.put(
+        f"/cases/{pub_id}",
+        json={"status": "published"},
+        headers=educator_headers,
+    )
+    assert up.status_code == 200
+
+    r = client.get("/cases", headers=learner_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 1
+    assert body[0]["case_id"] == "chest_pain_002"
+    assert body[0]["status"] == "published"
+
+
+def test_list_cases_educator_sees_all(
+    client: TestClient, educator_headers: dict[str, str]
+) -> None:
+    client.post("/cases", json=_minimal_case(), headers=educator_headers)
+    client.post(
+        "/cases", json=_minimal_case_alt("chest_pain_002"), headers=educator_headers
+    )
+    r = client.get("/cases", headers=educator_headers)
+    assert r.status_code == 200
+    assert len(r.json()) == 2
+
+
+def test_list_cases_educator_filter_by_status(
+    client: TestClient, educator_headers: dict[str, str]
+) -> None:
+    client.post("/cases", json=_minimal_case(), headers=educator_headers)
+    r2 = client.post(
+        "/cases", json=_minimal_case_alt("chest_pain_002"), headers=educator_headers
+    )
+    assert r2.status_code == 201
+    pub_id = r2.json()["id"]
+    client.put(
+        f"/cases/{pub_id}",
+        json={"status": "published"},
+        headers=educator_headers,
+    )
+
+    r = client.get("/cases?status=draft", headers=educator_headers)
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+    assert r.json()[0]["case_id"] == "chest_pain_001"
+
+
+def test_list_cases_unauthenticated(client: TestClient) -> None:
+    r = client.get("/cases")
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PUT /cases/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_update_case_success(
+    client: TestClient, educator_headers: dict[str, str]
+) -> None:
+    r = client.post("/cases", json=_minimal_case(), headers=educator_headers)
+    assert r.status_code == 201
+    case_id = r.json()["id"]
+
+    r2 = client.put(
+        f"/cases/{case_id}",
+        json={"title": "Updated title"},
+        headers=educator_headers,
+    )
+    assert r2.status_code == 200
+    assert r2.json()["title"] == "Updated title"
+
+
+def test_update_case_publish_bumps_version(
+    client: TestClient, educator_headers: dict[str, str]
+) -> None:
+    r = client.post("/cases", json=_minimal_case(), headers=educator_headers)
+    assert r.status_code == 201
+    case_id = r.json()["id"]
+    assert r.json()["version"] == 1
+
+    r2 = client.put(
+        f"/cases/{case_id}",
+        json={"status": "published"},
+        headers=educator_headers,
+    )
+    assert r2.status_code == 200
+    assert r2.json()["status"] == "published"
+    assert r2.json()["version"] == 2
+
+
+def test_update_case_learner_forbidden(
+    client: TestClient,
+    educator_headers: dict[str, str],
+    learner_headers: dict[str, str],
+) -> None:
+    r = client.post("/cases", json=_minimal_case(), headers=educator_headers)
+    case_id = r.json()["id"]
+    r2 = client.put(
+        f"/cases/{case_id}",
+        json={"title": "Hack"},
+        headers=learner_headers,
+    )
+    assert r2.status_code == 403
+
+
+def test_update_case_not_found(
+    client: TestClient, educator_headers: dict[str, str]
+) -> None:
+    r = client.put(
+        "/cases/00000000-0000-0000-0000-000000000000",
+        json={"title": "Nope"},
+        headers=educator_headers,
+    )
+    assert r.status_code == 404
+
+
+def test_update_case_unauthenticated(client: TestClient) -> None:
+    r = client.put(
+        "/cases/00000000-0000-0000-0000-000000000000",
+        json={"title": "Nope"},
+    )
+    assert r.status_code == 401


### PR DESCRIPTION
## Description

This PR adds the remaining backend case endpoints from issue #27: `GET /cases` and `PUT /cases/{id}`. It completes the cases CRUD flow that was started earlier with `POST /cases`.

## Related Issue

- Part of #27

## Subtasks Checklist

- [x] Add `GET /cases` endpoint
- [x] Restrict learners to published cases only
- [x] Allow educators to list all cases and filter by `status`
- [x] Add `PUT /cases/{id}` endpoint
- [x] Restrict case updates to educators only
- [x] Add/update tests for case listing and updating

## Verification of Acceptance Criteria

- [x] Educators can filter cases by `status` via API
  - `GET /cases?status=draft|review|published` is supported for educator accounts.
- [x] Learners only see published cases
  - Verified by test coverage for `GET /cases`.
- [x] `PUT /cases/{id}` updates case details
  - Verified by test coverage for updating title and status.
- [x] Publishing a case increments its version
  - Verified by test coverage for publishing flow.

## PR Checklist

- [x] I have linked the related issue.
- [x] My code follows the project's style guidelines.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests pass.