### PR TITLE
Feature/sessions start

### DIFF
--- a/backend/exceptions/auth_exceptions.py
+++ b/backend/exceptions/auth_exceptions.py
@@ -8,3 +8,11 @@ class AuthenticationError(Exception):
 
 class BadRequestError(Exception):
     pass
+
+
+class NotFoundError(Exception):
+    pass
+
+
+class ForbiddenError(Exception):
+    pass

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import JSON, Boolean, DateTime, Float, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.database import Base
@@ -256,4 +256,31 @@ class CaseSafetyError(Base):
     error: Mapped[str] = mapped_column(Text, nullable=False)
     case: Mapped[ClinicalCase] = relationship(
         "ClinicalCase", back_populates="safety_errors"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case Session
+# ---------------------------------------------------------------------------
+
+
+class CaseSession(Base):
+    __tablename__ = "case_sessions"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    session_id: Mapped[str] = mapped_column(
+        String, unique=True, nullable=False, default=_uuid
+    )
+    user_id: Mapped[str] = mapped_column(
+        String, ForeignKey("users.id"), nullable=False
+    )
+    clinical_case_id: Mapped[str] = mapped_column(
+        String, ForeignKey("clinical_cases.id"), nullable=False
+    )
+    status: Mapped[str] = mapped_column(
+        String, nullable=False, default="active"
+    )  # active|completed|abandoned
+    frozen_case_snapshot: Mapped[dict] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[DateTime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -1,4 +1,6 @@
 import uuid
+from datetime import datetime
+from typing import Any
 
 from sqlalchemy import JSON, Boolean, DateTime, Float, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -280,7 +282,7 @@ class CaseSession(Base):
     status: Mapped[str] = mapped_column(
         String, nullable=False, default="active"
     )  # active|completed|abandoned
-    frozen_case_snapshot: Mapped[dict] = mapped_column(JSON, nullable=False)
-    created_at: Mapped[DateTime] = mapped_column(
+    frozen_case_snapshot: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/server.py
+++ b/backend/server.py
@@ -21,7 +21,11 @@ from models.database import Base
 from repositories.user_repository import UserRepository
 from cases.router import router as cases_router
 from routers import login, refresh, reset_password, signup, verify
+<<<<<<< HEAD
 from services.utils.auth import hash_password
+=======
+from sessions.router import router as sessions_router
+>>>>>>> 97d1017 (feat(backend): sessions:#28)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -91,3 +95,4 @@ app.include_router(refresh.router, prefix="/auth", tags=["auth"])
 app.include_router(verify.router, prefix="/auth", tags=["auth"])
 app.include_router(reset_password.router, prefix="/auth", tags=["auth"])
 app.include_router(cases_router)
+app.include_router(sessions_router)

--- a/backend/server.py
+++ b/backend/server.py
@@ -6,26 +6,13 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 import models.database as _db
-from config import (
-    ADMIN_EMAIL,
-    ADMIN_PASSWORD,
-    ADMIN_USERNAME,
-    EDUCATOR_EMAIL,
-    EDUCATOR_PASSWORD,
-    EDUCATOR_USERNAME,
-    LEARNER_EMAIL,
-    LEARNER_PASSWORD,
-    LEARNER_USERNAME,
-)
+from config import ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_USERNAME
 from models.database import Base
 from repositories.user_repository import UserRepository
 from cases.router import router as cases_router
 from routers import login, refresh, reset_password, signup, verify
-<<<<<<< HEAD
-from services.utils.auth import hash_password
-=======
 from sessions.router import router as sessions_router
->>>>>>> 97d1017 (feat(backend): sessions:#28)
+from services.utils.auth import hash_password
 
 logging.basicConfig(level=logging.INFO)
 
@@ -49,32 +36,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.info("Admin user seeded: %s", ADMIN_USERNAME)
         else:
             logger.info("Admin user already exists, skipping seed")
-
-        if not await repo.exists_by_username_or_email(
-            EDUCATOR_USERNAME, EDUCATOR_EMAIL
-        ):
-            await repo.create(
-                EDUCATOR_USERNAME,
-                EDUCATOR_EMAIL,
-                hash_password(EDUCATOR_PASSWORD),
-                role="educator",
-            )
-            logger.info("Educator user seeded: %s", EDUCATOR_USERNAME)
-        else:
-            logger.info("Educator user already exists, skipping seed")
-
-        if not await repo.exists_by_username_or_email(
-            LEARNER_USERNAME, LEARNER_EMAIL
-        ):
-            await repo.create(
-                LEARNER_USERNAME,
-                LEARNER_EMAIL,
-                hash_password(LEARNER_PASSWORD),
-                role="learner",
-            )
-            logger.info("Learner user seeded: %s", LEARNER_USERNAME)
-        else:
-            logger.info("Learner user already exists, skipping seed")
 
     yield
 

--- a/backend/sessions/repository.py
+++ b/backend/sessions/repository.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,7 +14,7 @@ class SessionRepository:
         self,
         user_id: str,
         clinical_case_id: str,
-        snapshot: dict,
+        snapshot: dict[str, Any],
     ) -> CaseSession:
         record = CaseSession(
             user_id=user_id,

--- a/backend/sessions/repository.py
+++ b/backend/sessions/repository.py
@@ -1,0 +1,31 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.db import CaseSession
+
+
+class SessionRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(
+        self,
+        user_id: str,
+        clinical_case_id: str,
+        snapshot: dict,
+    ) -> CaseSession:
+        record = CaseSession(
+            user_id=user_id,
+            clinical_case_id=clinical_case_id,
+            frozen_case_snapshot=snapshot,
+        )
+        self._session.add(record)
+        await self._session.commit()
+        await self._session.refresh(record)
+        return record
+
+    async def get_by_session_id(self, session_id: str) -> CaseSession | None:
+        result = await self._session.execute(
+            select(CaseSession).where(CaseSession.session_id == session_id)
+        )
+        return result.scalar_one_or_none()

--- a/backend/sessions/request.py
+++ b/backend/sessions/request.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class StartSessionRequest(BaseModel):
+    case_id: str 

--- a/backend/sessions/response.py
+++ b/backend/sessions/response.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class SessionResponse(BaseModel):
+    session_id: str
+    case_id: str
+    status: str
+    created_at: datetime

--- a/backend/sessions/router.py
+++ b/backend/sessions/router.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from cases.repository import CaseRepository
+from cases.router import get_case_repo
+from dependencies import get_current_user, get_db
+from exceptions.auth_exceptions import ForbiddenError, NotFoundError
+from models.db import User
+from sessions import service
+from sessions.repository import SessionRepository
+from sessions.request import StartSessionRequest
+from sessions.response import SessionResponse
+
+router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+
+def get_session_repo(db: AsyncSession = Depends(get_db)) -> SessionRepository:
+    return SessionRepository(db)
+
+
+@router.post(
+    "/start",
+    response_model=SessionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def start_session(
+    data: StartSessionRequest,
+    current_user: User = Depends(get_current_user),
+    case_repo: CaseRepository = Depends(get_case_repo),
+    session_repo: SessionRepository = Depends(get_session_repo),
+) -> SessionResponse:
+    try:
+        return await service.start_session(
+            data.case_id, current_user, case_repo, session_repo
+        )
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ForbiddenError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc

--- a/backend/sessions/service.py
+++ b/backend/sessions/service.py
@@ -1,0 +1,34 @@
+from cases.repository import CaseRepository
+from cases.service import _to_response
+from exceptions.auth_exceptions import ForbiddenError, NotFoundError
+from models.db import User
+from sessions.repository import SessionRepository
+from sessions.response import SessionResponse
+
+
+async def start_session(
+    case_id: str,
+    current_user: User,
+    case_repo: CaseRepository,
+    session_repo: SessionRepository,
+) -> SessionResponse:
+    case = await case_repo.get_by_case_id(case_id)
+    if case is None:
+        raise NotFoundError(f"Case '{case_id}' not found")
+
+    
+    if case.status != "published" and current_user.role == "learner":
+        raise ForbiddenError("Learners can only start published cases")
+
+    snapshot = _to_response(case).model_dump(mode="json")
+    session = await session_repo.create(
+        user_id=current_user.id,
+        clinical_case_id=case.id,
+        snapshot=snapshot,
+    )
+    return SessionResponse(
+        session_id=session.session_id,
+        case_id=case_id,
+        status=session.status,
+        created_at=session.created_at,
+    )

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1,0 +1,193 @@
+"""Integration tests for POST /sessions/start (Session Initialization)."""
+import asyncio
+from typing import Any, cast
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+import models.database as database
+from models.db import ClinicalCase
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_case(case_id: str = "session_case_001") -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "title": "Acute chest pain",
+        "language": "en",
+        "difficulty": "medium",
+        "specialty": "emergency_medicine",
+        "tags": ["chest_pain"],
+        "age": 54,
+        "sex": "male",
+        "persona": "Worried delivery driver.",
+        "tone_presets": ["neutral"],
+        "chief_complaint": "Chest pain",
+        "history_of_present_illness": "Substernal pressure for 45 minutes.",
+        "key_history_points": {
+            "must_ask": ["Onset and duration"],
+            "nice_to_ask": ["Recent exertion"],
+            "red_flags": ["Syncope"],
+        },
+        "final_diagnosis": "STEMI",
+        "differential": ["STEMI", "Unstable angina"],
+        "severity_or_stage": None,
+        "investigations": {
+            "catalog_hints": ["ECG"],
+            "expected": {
+                "must_order": ["ECG"],
+                "optional": [],
+                "should_not_order": [],
+            },
+            "results": [
+                {
+                    "test_name": "ECG",
+                    "result_type": "text_report",
+                    "value": "ST elevation.",
+                    "unit": None,
+                    "reference_range": None,
+                }
+            ],
+        },
+        "management": {
+            "diagnostic_plan": ["Immediate ECG"],
+            "treatment_plan": ["Activate cath lab"],
+            "contraindications": [],
+            "follow_up": [],
+        },
+        "scoring": {
+            "weight_diagnosis": 0.35,
+            "weight_diagnostics": 0.25,
+            "weight_treatment": 0.30,
+            "weight_safety": 0.10,
+            "acceptable_answers": [
+                {"field": "final_diagnosis", "answer": "STEMI"}
+            ],
+            "critical_safety_errors": [],
+        },
+    }
+
+
+def _publish_case(case_id: str) -> None:
+    """Flip a case's status to 'published' directly in the test DB."""
+
+    async def _run() -> None:
+        session_factory = cast(
+            async_sessionmaker[AsyncSession],
+            database._TestSessionLocal,  # type: ignore[attr-defined]
+        )
+        async with session_factory() as session:
+            await session.execute(
+                update(ClinicalCase)
+                .where(ClinicalCase.case_id == case_id)
+                .values(status="published")
+            )
+            await session.commit()
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def draft_case_id(client: TestClient, educator_headers: dict[str, str]) -> str:
+    """Create a draft case and return its case_id string."""
+    payload = _minimal_case("session_draft_001")
+    r = client.post("/cases", json=payload, headers=educator_headers)
+    assert r.status_code == 201
+    return str(r.json()["case_id"])
+
+
+@pytest.fixture()
+def published_case_id(client: TestClient, educator_headers: dict[str, str]) -> str:
+    """Create a case and immediately publish it, return its case_id string."""
+    payload = _minimal_case("session_published_001")
+    r = client.post("/cases", json=payload, headers=educator_headers)
+    assert r.status_code == 201
+    cid: str = r.json()["case_id"]
+    _publish_case(cid)
+    return cid
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_start_session_published_case_learner(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    published_case_id: str,
+) -> None:
+    """AC #1 — POST /sessions/start returns 201 with a unique session_id."""
+    r = client.post(
+        "/sessions/start",
+        json={"case_id": published_case_id},
+        headers=learner_headers,
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert "session_id" in body
+    assert body["case_id"] == published_case_id
+    assert body["status"] == "active"
+    assert "created_at" in body
+
+
+def test_start_session_draft_case_learner_forbidden(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    draft_case_id: str,
+) -> None:
+    """AC #2 — Learners cannot start a draft case (403 Forbidden)."""
+    r = client.post(
+        "/sessions/start",
+        json={"case_id": draft_case_id},
+        headers=learner_headers,
+    )
+    assert r.status_code == 403
+
+
+def test_start_session_draft_case_educator_allowed(
+    client: TestClient,
+    educator_headers: dict[str, str],
+    draft_case_id: str,
+) -> None:
+    """Educators can start even draft cases (no status restriction)."""
+    r = client.post(
+        "/sessions/start",
+        json={"case_id": draft_case_id},
+        headers=educator_headers,
+    )
+    assert r.status_code == 201
+    assert "session_id" in r.json()
+
+
+def test_start_session_nonexistent_case(
+    client: TestClient,
+    learner_headers: dict[str, str],
+) -> None:
+    """Requesting a non-existent case_id returns 404 Not Found."""
+    r = client.post(
+        "/sessions/start",
+        json={"case_id": "does_not_exist_xyz"},
+        headers=learner_headers,
+    )
+    assert r.status_code == 404
+
+
+def test_start_session_unauthenticated(client: TestClient) -> None:
+    """Unauthenticated request returns 401 Unauthorized."""
+    r = client.post(
+        "/sessions/start",
+        json={"case_id": "any_case"},
+    )
+    assert r.status_code == 401


### PR DESCRIPTION
## Description

This PR implements the backend Session Lifecycle API entrypoint by adding `POST /sessions/start`.  
It connects case selection to simulation start by validating case access rules and persisting a new active session with a frozen case snapshot.

## Related Issue

- Related to #28

## Subtasks Checklist

- [x] Add `POST /sessions/start` endpoint.
- [x] Accept `case_id` in request payload.
- [x] Validate case existence and return `404` when case is missing.
- [x] Enforce role/status rule: learner cannot start draft case (`403`).
- [x] Persist session record in DB (`case_sessions`) with frozen case snapshot.
- [x] Return session metadata (`session_id`, `case_id`, `status`, `created_at`).
- [x] Register sessions router in backend app.
- [x] Add integration tests for session start scenarios.

## Verification of Acceptance Criteria

- [x] `POST /sessions/start` returns a unique `session_id`.
  - Verified by `tests/test_sessions.py::test_start_session_published_case_learner`.
- [x] Attempting to start a Draft case as a Learner returns `403 Forbidden`.
  - Verified by `tests/test_sessions.py::test_start_session_draft_case_learner_forbidden`.
- [ ] Session initialization happens within QA-PERF-04 (<500ms).
  - Functional initialization flow is implemented and tested.
  - Dedicated performance benchmark/assertion is not included in this PR.

### PR Checklist

- [x] I have linked the related issue.
- [x] My code follows the project's style guidelines.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests pass.