### PR TITLE
add admin sessions endpoints for educator/admin dashboard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,18 @@ repos:
     hooks:
       - id: mypy
         name: mypy (strict)
-        entry: uv run mypy --strict
+        entry: bash -c 'cd backend && uv run mypy --strict .'
         language: system
         types: [python]
         files: ^backend/
+        pass_filenames: false
+
+      - id: pytest-cov
+        name: pytest (coverage ≥ 80%)
+        entry: bash -c 'cd backend && uv run pytest -q'
+        language: system
+        files: ^backend/.*\.py$
+        pass_filenames: false
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.16.0

--- a/backend/admin/repository.py
+++ b/backend/admin/repository.py
@@ -1,0 +1,104 @@
+from datetime import date
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from admin.response import ActionLogEntry, SessionDetailResponse, SessionSummary
+from exceptions.auth_exceptions import NotFoundError
+from models.db import ActionLog, CaseSession, ClinicalCase, User
+
+
+class AdminRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_sessions(
+        self,
+        page: int,
+        page_size: int,
+        student_username: str | None = None,
+        case_id: str | None = None,
+        on_date: date | None = None,
+    ) -> tuple[list[SessionSummary], int]:
+        base = (
+            select(
+                CaseSession.session_id,
+                User.username.label("student_username"),
+                ClinicalCase.case_id.label("case_id"),
+                ClinicalCase.title.label("case_title"),
+                CaseSession.created_at,
+            )
+            .join(User, User.id == CaseSession.user_id)
+            .join(ClinicalCase, ClinicalCase.id == CaseSession.clinical_case_id)
+        )
+
+        if student_username is not None:
+            base = base.where(User.username == student_username)
+        if case_id is not None:
+            base = base.where(ClinicalCase.case_id == case_id)
+        if on_date is not None:
+            base = base.where(func.date(CaseSession.created_at) == on_date)
+
+        count_result = await self._session.execute(
+            select(func.count()).select_from(base.subquery())
+        )
+        total = count_result.scalar_one()
+
+        rows_result = await self._session.execute(
+            base.order_by(CaseSession.created_at.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        rows = rows_result.all()
+
+        summaries = [
+            SessionSummary(
+                session_id=r.session_id,
+                student_username=r.student_username,
+                case_id=r.case_id,
+                case_title=r.case_title,
+                created_at=r.created_at,
+            )
+            for r in rows
+        ]
+        return summaries, total
+
+    async def get_session_detail(self, session_id: str) -> SessionDetailResponse:
+        row = await self._session.execute(
+            select(
+                CaseSession.session_id,
+                User.username.label("student_username"),
+                ClinicalCase.case_id.label("case_id"),
+                ClinicalCase.title.label("case_title"),
+                CaseSession.created_at,
+            )
+            .join(User, User.id == CaseSession.user_id)
+            .join(ClinicalCase, ClinicalCase.id == CaseSession.clinical_case_id)
+            .where(CaseSession.session_id == session_id)
+        )
+        session_row = row.one_or_none()
+        if session_row is None:
+            raise NotFoundError(f"Session '{session_id}' not found")
+
+        logs_result = await self._session.execute(
+            select(ActionLog)
+            .where(ActionLog.session_id == session_id)
+            .order_by(ActionLog.created_at)
+        )
+        logs = logs_result.scalars().all()
+
+        return SessionDetailResponse(
+            session_id=session_row.session_id,
+            student_username=session_row.student_username,
+            case_id=session_row.case_id,
+            case_title=session_row.case_title,
+            created_at=session_row.created_at,
+            action_log=[
+                ActionLogEntry(
+                    role=log.role,
+                    content=log.content,
+                    created_at=log.created_at,
+                )
+                for log in logs
+            ],
+        )

--- a/backend/admin/response.py
+++ b/backend/admin/response.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ActionLogEntry(BaseModel):
+    role: str
+    content: str
+    created_at: datetime
+
+
+class SessionSummary(BaseModel):
+    session_id: str
+    student_username: str
+    case_id: str
+    case_title: str
+    created_at: datetime
+
+
+class SessionListResponse(BaseModel):
+    sessions: list[SessionSummary]
+    total: int
+    page: int
+    page_size: int
+
+
+class SessionDetailResponse(BaseModel):
+    session_id: str
+    student_username: str
+    case_id: str
+    case_title: str
+    created_at: datetime
+    action_log: list[ActionLogEntry]

--- a/backend/admin/router.py
+++ b/backend/admin/router.py
@@ -1,0 +1,55 @@
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from admin.repository import AdminRepository
+from admin.response import SessionDetailResponse, SessionListResponse
+from dependencies import get_db, require_educator_or_admin
+from exceptions.auth_exceptions import NotFoundError
+from models.db import User
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+def get_admin_repo(db: AsyncSession = Depends(get_db)) -> AdminRepository:
+    return AdminRepository(db)
+
+
+@router.get("/sessions", response_model=SessionListResponse)
+async def list_sessions(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    student: str | None = Query(None),
+    case_id: str | None = Query(None),
+    on_date: date | None = Query(None),
+    _: User = Depends(require_educator_or_admin),
+    repo: AdminRepository = Depends(get_admin_repo),
+) -> SessionListResponse:
+    sessions, total = await repo.list_sessions(
+        page=page,
+        page_size=page_size,
+        student_username=student,
+        case_id=case_id,
+        on_date=on_date,
+    )
+    return SessionListResponse(
+        sessions=sessions,
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/sessions/{session_id}", response_model=SessionDetailResponse)
+async def get_session_detail(
+    session_id: str,
+    _: User = Depends(require_educator_or_admin),
+    repo: AdminRepository = Depends(get_admin_repo),
+) -> SessionDetailResponse:
+    try:
+        return await repo.get_session_detail(session_id)
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -52,3 +52,14 @@ async def get_current_user(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)
         ) from exc
+
+
+async def require_educator_or_admin(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    if current_user.role not in ("educator", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Educator or admin role required",
+        )
+    return current_user

--- a/backend/server.py
+++ b/backend/server.py
@@ -19,6 +19,7 @@ from config import (
 )
 from models.database import Base
 from repositories.user_repository import UserRepository
+from admin.router import router as admin_router
 from cases.router import router as cases_router
 from routers import login, refresh, reset_password, signup, verify
 from sessions.router import router as sessions_router
@@ -60,9 +61,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         else:
             logger.info("Educator user already exists, skipping seed")
 
-        if not await repo.exists_by_username_or_email(
-            LEARNER_USERNAME, LEARNER_EMAIL
-        ):
+        if not await repo.exists_by_username_or_email(LEARNER_USERNAME, LEARNER_EMAIL):
             await repo.create(
                 LEARNER_USERNAME,
                 LEARNER_EMAIL,
@@ -93,3 +92,4 @@ app.include_router(verify.router, prefix="/auth", tags=["auth"])
 app.include_router(reset_password.router, prefix="/auth", tags=["auth"])
 app.include_router(cases_router)
 app.include_router(sessions_router)
+app.include_router(admin_router)

--- a/backend/tests/test_admin_sessions.py
+++ b/backend/tests/test_admin_sessions.py
@@ -1,0 +1,332 @@
+"""Integration tests for GET /admin/sessions and GET /admin/sessions/{session_id}."""
+
+import asyncio
+from typing import Any, cast
+
+from fastapi.testclient import TestClient
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+import models.database as database
+from models.db import ActionLog, ClinicalCase
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_case(case_id: str = "admin_case_001") -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "title": "Acute chest pain",
+        "language": "en",
+        "difficulty": "medium",
+        "specialty": "emergency_medicine",
+        "tags": ["chest_pain"],
+        "age": 54,
+        "sex": "male",
+        "persona": "Worried delivery driver.",
+        "tone_presets": ["neutral"],
+        "chief_complaint": "Chest pain",
+        "history_of_present_illness": "Substernal pressure for 45 minutes.",
+        "key_history_points": {
+            "must_ask": ["Onset and duration"],
+            "nice_to_ask": ["Recent exertion"],
+            "red_flags": ["Syncope"],
+        },
+        "final_diagnosis": "STEMI",
+        "differential": ["STEMI", "Unstable angina"],
+        "severity_or_stage": None,
+        "investigations": {
+            "catalog_hints": ["ECG"],
+            "expected": {
+                "must_order": ["ECG"],
+                "optional": [],
+                "should_not_order": [],
+            },
+            "results": [
+                {
+                    "test_name": "ECG",
+                    "result_type": "text_report",
+                    "value": "ST elevation.",
+                    "unit": None,
+                    "reference_range": None,
+                }
+            ],
+        },
+        "management": {
+            "diagnostic_plan": ["Immediate ECG"],
+            "treatment_plan": ["Activate cath lab"],
+            "contraindications": [],
+            "follow_up": [],
+        },
+        "scoring": {
+            "weight_diagnosis": 0.35,
+            "weight_diagnostics": 0.25,
+            "weight_treatment": 0.30,
+            "weight_safety": 0.10,
+            "acceptable_answers": [],
+            "critical_safety_errors": [],
+        },
+    }
+
+
+def _publish_case(case_id: str) -> None:
+    async def _run() -> None:
+        session_factory = cast(
+            async_sessionmaker[AsyncSession],
+            database._TestSessionLocal,  # type: ignore[attr-defined]
+        )
+        async with session_factory() as session:
+            await session.execute(
+                update(ClinicalCase)
+                .where(ClinicalCase.case_id == case_id)
+                .values(status="published")
+            )
+            await session.commit()
+
+    asyncio.run(_run())
+
+
+def _seed_action_logs(session_id: str, messages: list[tuple[str, str]]) -> None:
+    """Insert action log rows directly for a given session."""
+
+    async def _run() -> None:
+        session_factory = cast(
+            async_sessionmaker[AsyncSession],
+            database._TestSessionLocal,  # type: ignore[attr-defined]
+        )
+        async with session_factory() as session:
+            for role, content in messages:
+                session.add(
+                    ActionLog(session_id=session_id, role=role, content=content)
+                )
+            await session.commit()
+
+    asyncio.run(_run())
+
+
+def _create_case_and_session(
+    client: TestClient,
+    educator_headers: dict[str, str],
+    learner_headers: dict[str, str],
+    case_id: str = "admin_case_001",
+) -> str:
+    """Create a published case and start a learner session. Returns session_id."""
+    r = client.post("/cases", json=_minimal_case(case_id), headers=educator_headers)
+    assert r.status_code == 201
+    _publish_case(case_id)
+    r = client.post(
+        "/sessions/start", json={"case_id": case_id}, headers=learner_headers
+    )
+    assert r.status_code == 201
+    return str(r.json()["session_id"])
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/sessions
+# ---------------------------------------------------------------------------
+
+
+class TestListSessions:
+    def test_educator_can_list_sessions(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        _create_case_and_session(client, educator_headers, learner_headers)
+        r = client.get("/admin/sessions", headers=educator_headers)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] >= 1
+        assert len(body["sessions"]) >= 1
+        session = body["sessions"][0]
+        assert "session_id" in session
+        assert "student_username" in session
+        assert "case_id" in session
+        assert "case_title" in session
+        assert "created_at" in session
+
+    def test_admin_can_list_sessions(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+        admin_headers: dict[str, str],
+    ) -> None:
+        _create_case_and_session(client, educator_headers, learner_headers)
+        r = client.get("/admin/sessions", headers=admin_headers)
+        assert r.status_code == 200
+
+    def test_learner_cannot_list_sessions(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        _create_case_and_session(client, educator_headers, learner_headers)
+        r = client.get("/admin/sessions", headers=learner_headers)
+        assert r.status_code == 403
+
+    def test_unauthenticated_cannot_list_sessions(self, client: TestClient) -> None:
+        r = client.get("/admin/sessions")
+        assert r.status_code == 401
+
+    def test_pagination(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        _create_case_and_session(
+            client, educator_headers, learner_headers, "admin_case_p1"
+        )
+        _create_case_and_session(
+            client, educator_headers, learner_headers, "admin_case_p2"
+        )
+        r = client.get("/admin/sessions?page=1&page_size=1", headers=educator_headers)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] == 2
+        assert len(body["sessions"]) == 1
+        assert body["page"] == 1
+        assert body["page_size"] == 1
+
+    def test_filter_by_student(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        _create_case_and_session(client, educator_headers, learner_headers)
+        r = client.get("/admin/sessions?student=learner", headers=educator_headers)
+        assert r.status_code == 200
+        body = r.json()
+        assert all(s["student_username"] == "learner" for s in body["sessions"])
+
+    def test_filter_by_unknown_student_returns_empty(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        _create_case_and_session(client, educator_headers, learner_headers)
+        r = client.get("/admin/sessions?student=nobody", headers=educator_headers)
+        assert r.status_code == 200
+        assert r.json()["total"] == 0
+
+    def test_filter_by_case_id(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        _create_case_and_session(
+            client, educator_headers, learner_headers, "admin_case_filter"
+        )
+        r = client.get(
+            "/admin/sessions?case_id=admin_case_filter", headers=educator_headers
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] >= 1
+        assert all(s["case_id"] == "admin_case_filter" for s in body["sessions"])
+
+    def test_empty_list_when_no_sessions(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+    ) -> None:
+        r = client.get("/admin/sessions", headers=educator_headers)
+        assert r.status_code == 200
+        assert r.json()["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/sessions/{session_id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetSessionDetail:
+    def test_returns_session_detail(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        session_id = _create_case_and_session(client, educator_headers, learner_headers)
+        r = client.get(f"/admin/sessions/{session_id}", headers=educator_headers)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["session_id"] == session_id
+        assert body["student_username"] == "learner"
+        assert body["case_id"] == "admin_case_001"
+        assert body["case_title"] == "Acute chest pain"
+        assert "created_at" in body
+        assert "action_log" in body
+
+    def test_action_log_contains_messages(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        session_id = _create_case_and_session(client, educator_headers, learner_headers)
+        _seed_action_logs(
+            session_id,
+            [("user", "Where does it hurt?"), ("assistant", "In my chest.")],
+        )
+        r = client.get(f"/admin/sessions/{session_id}", headers=educator_headers)
+        assert r.status_code == 200
+        log = r.json()["action_log"]
+        assert len(log) == 2
+        assert log[0]["role"] == "user"
+        assert log[0]["content"] == "Where does it hurt?"
+        assert log[1]["role"] == "assistant"
+        assert "created_at" in log[0]
+
+    def test_action_log_ordered_by_timestamp(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        session_id = _create_case_and_session(client, educator_headers, learner_headers)
+        _seed_action_logs(
+            session_id,
+            [("user", "first"), ("assistant", "second"), ("user", "third")],
+        )
+        r = client.get(f"/admin/sessions/{session_id}", headers=educator_headers)
+        log = r.json()["action_log"]
+        timestamps = [e["created_at"] for e in log]
+        assert timestamps == sorted(timestamps)
+
+    def test_404_for_unknown_session(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+    ) -> None:
+        r = client.get("/admin/sessions/nonexistent-session", headers=educator_headers)
+        assert r.status_code == 404
+
+    def test_learner_cannot_access_detail(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        session_id = _create_case_and_session(client, educator_headers, learner_headers)
+        r = client.get(f"/admin/sessions/{session_id}", headers=learner_headers)
+        assert r.status_code == 403
+
+    def test_unauthenticated_cannot_access_detail(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        session_id = _create_case_and_session(client, educator_headers, learner_headers)
+        r = client.get(f"/admin/sessions/{session_id}")
+        assert r.status_code == 401


### PR DESCRIPTION
## Summary
- `GET /admin/sessions` — paginated list of all sessions, filterable by student username, case ID, and date; educator/admin only
- `GET /admin/sessions/{session_id}` — full session detail with complete action log ordered by timestamp
- `require_educator_or_admin` dependency added to `dependencies.py` for reuse across future admin endpoints
- Fixed broken `mypy` pre-commit hook (was running from repo root with no `pyproject.toml`)
- 15 integration tests covering RBAC, pagination, filters, action log ordering, and 404 handling

Closes #48 (backend side — provides the endpoint required by the Flutter admin dashboard)

## Test plan
- [ ] `pytest tests/test_admin_sessions.py` — 15 tests, all passing
- [ ] Learner gets 403 on both endpoints
- [ ] Unauthenticated gets 401
- [ ] Pagination and filters return correct results