### PR TITLE
Add communication evaluation API with LLM judge (#69)

### DIFF
--- a/backend/alembic/versions/003_add_communication_evaluations.py
+++ b/backend/alembic/versions/003_add_communication_evaluations.py
@@ -1,0 +1,53 @@
+"""Add communication_evaluations and communication_criteria tables.
+
+Revision ID: 003_add_communication_evaluations
+Revises: 002_add_last_activity_at
+Create Date: 2026-06-19
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "003_add_communication_evaluations"
+down_revision: Union[str, Sequence[str], None] = "002_add_last_activity_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "communication_evaluations",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("prompt_version", sa.String(), nullable=False),
+        sa.Column("total_score", sa.Float(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["session_id"], ["case_sessions.session_id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("session_id"),
+    )
+    op.create_table(
+        "communication_criteria",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("evaluation_id", sa.String(), nullable=False),
+        sa.Column("criterion", sa.String(), nullable=False),
+        sa.Column("score", sa.Integer(), nullable=False),
+        sa.Column("rationale", sa.Text(), nullable=False),
+        sa.Column("quote", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["evaluation_id"], ["communication_evaluations.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("communication_criteria")
+    op.drop_table("communication_evaluations")

--- a/backend/communication_eval/judge.py
+++ b/backend/communication_eval/judge.py
@@ -1,0 +1,94 @@
+import json
+import re
+
+from pydantic import ValidationError
+
+from core.provider import AIProvider
+from exceptions.auth_exceptions import JudgeError
+from models.db import ActionLog
+
+from communication_eval.judge_schemas import (
+    CRITERION_NAMES,
+    JudgeOutput,
+    compute_total_score,
+)
+
+JUDGE_MARKER = "COMMUNICATION_JUDGE_V1"
+
+
+def build_transcript(logs: list[ActionLog]) -> str:
+    chat_logs = [log for log in logs if log.role in ("user", "assistant")]
+    if not chat_logs:
+        return "(No doctor-patient dialogue recorded.)"
+
+    lines: list[str] = []
+    for index, log in enumerate(chat_logs, start=1):
+        speaker = "Doctor" if log.role == "user" else "Patient"
+        lines.append(f"{index}. {speaker}: {log.content}")
+    return "\n".join(lines)
+
+
+def build_system_prompt() -> str:
+    criteria_list = ", ".join(CRITERION_NAMES)
+    return f"""{JUDGE_MARKER}
+You are a medical communication skills evaluator. Score ONLY the doctor's communication style.
+Do NOT provide clinical advice, diagnoses, or treatment recommendations.
+
+Evaluate the transcript against these criteria: {criteria_list}.
+Each criterion score must be an integer from 0 to 5.
+
+Respond with JSON only, matching this schema:
+{{
+  "criteria": [
+    {{
+      "criterion": "<one of the criterion names>",
+      "score": <0-5>,
+      "rationale": "<brief explanation>",
+      "quote": "<short verbatim excerpt from the transcript>"
+    }}
+  ]
+}}
+
+Include exactly one entry per criterion. Use temperature-neutral, consistent scoring."""
+
+
+def build_user_prompt(transcript: str) -> str:
+    return (
+        f"Score the following doctor-patient transcript.\n\nTRANSCRIPT:\n{transcript}"
+    )
+
+
+def _strip_json_fences(raw: str) -> str:
+    text = raw.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"\s*```$", "", text)
+    return text.strip()
+
+
+async def run_judge(
+    logs: list[ActionLog],
+    provider: AIProvider,
+) -> tuple[JudgeOutput, float]:
+    transcript = build_transcript(logs)
+    messages = [
+        {"role": "system", "content": build_system_prompt()},
+        {"role": "user", "content": build_user_prompt(transcript)},
+    ]
+
+    try:
+        raw = await provider.complete(
+            messages,
+            temperature=0.0,
+            json_mode=True,
+        )
+    except Exception as exc:
+        raise JudgeError("LLM provider failed during communication evaluation") from exc
+
+    try:
+        payload = json.loads(_strip_json_fences(raw))
+        result = JudgeOutput.model_validate(payload)
+    except (json.JSONDecodeError, ValidationError, ValueError) as exc:
+        raise JudgeError("LLM returned invalid communication evaluation JSON") from exc
+
+    return result, compute_total_score(result.criteria)

--- a/backend/communication_eval/judge_schemas.py
+++ b/backend/communication_eval/judge_schemas.py
@@ -1,0 +1,53 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+CRITERION_NAMES = (
+    "open_ended_questions",
+    "empathy",
+    "structured_history",
+    "closing_the_loop",
+    "no_leading_questions",
+)
+
+CriterionName = Literal[
+    "open_ended_questions",
+    "empathy",
+    "structured_history",
+    "closing_the_loop",
+    "no_leading_questions",
+]
+
+
+class JudgeCriterionOutput(BaseModel):
+    criterion: CriterionName
+    score: int = Field(ge=0, le=5)
+    rationale: str
+    quote: str
+
+
+class JudgeOutput(BaseModel):
+    criteria: list[JudgeCriterionOutput]
+
+    @field_validator("criteria")
+    @classmethod
+    def all_criteria_present(
+        cls, value: list[JudgeCriterionOutput]
+    ) -> list[JudgeCriterionOutput]:
+        found: set[str] = {item.criterion for item in value}
+        expected = set(CRITERION_NAMES)
+        if found != expected:
+            missing = expected - found
+            extra = found - expected
+            parts: list[str] = []
+            if missing:
+                parts.append(f"missing: {sorted(missing)}")
+            if extra:
+                parts.append(f"unexpected: {sorted(extra)}")
+            raise ValueError("; ".join(parts))
+        return value
+
+
+def compute_total_score(criteria: list[JudgeCriterionOutput]) -> float:
+    total_points = sum(item.score for item in criteria)
+    return round((total_points / 25.0) * 100.0, 1)

--- a/backend/communication_eval/repository.py
+++ b/backend/communication_eval/repository.py
@@ -1,0 +1,55 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from communication_eval.judge_schemas import JudgeOutput
+from models.db import CommunicationCriterion, CommunicationEvaluation
+
+
+class CommunicationEvaluationRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_session_id(
+        self, session_id: str
+    ) -> CommunicationEvaluation | None:
+        result = await self._session.execute(
+            select(CommunicationEvaluation)
+            .options(selectinload(CommunicationEvaluation.criteria))
+            .where(CommunicationEvaluation.session_id == session_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        session_id: str,
+        model: str,
+        prompt_version: str,
+        total_score: float,
+        judge_output: JudgeOutput,
+    ) -> CommunicationEvaluation:
+        record = CommunicationEvaluation(
+            session_id=session_id,
+            model=model,
+            prompt_version=prompt_version,
+            total_score=total_score,
+            criteria=[
+                CommunicationCriterion(
+                    criterion=item.criterion,
+                    score=item.score,
+                    rationale=item.rationale,
+                    quote=item.quote,
+                )
+                for item in judge_output.criteria
+            ],
+        )
+        self._session.add(record)
+        await self._session.commit()
+        await self._session.refresh(record)
+        loaded = await self.get_by_session_id(session_id)
+        if loaded is None:
+            raise RuntimeError(
+                f"Communication evaluation for session '{session_id}' "
+                "was not found after create"
+            )
+        return loaded

--- a/backend/communication_eval/response.py
+++ b/backend/communication_eval/response.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CommunicationCriterionResponse(BaseModel):
+    criterion: str
+    score: int
+    rationale: str
+    quote: str
+
+
+class CommunicationEvaluationResponse(BaseModel):
+    session_id: str
+    model: str
+    prompt_version: str
+    total_score: float
+    created_at: datetime
+    criteria: list[CommunicationCriterionResponse]
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "session_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "model": "mock",
+                    "prompt_version": "v1",
+                    "total_score": 76.0,
+                    "created_at": "2026-06-19T12:00:00Z",
+                    "criteria": [
+                        {
+                            "criterion": "open_ended_questions",
+                            "score": 4,
+                            "rationale": "Used open-ended questions.",
+                            "quote": "Can you tell me more?",
+                        }
+                    ],
+                }
+            ]
+        }
+    )

--- a/backend/communication_eval/router.py
+++ b/backend/communication_eval/router.py
@@ -1,0 +1,100 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from communication_eval import service
+from communication_eval.repository import CommunicationEvaluationRepository
+from communication_eval.response import CommunicationEvaluationResponse
+from core.provider import AIProvider
+from dependencies import get_current_user, get_db, get_judge_provider
+from exceptions.auth_exceptions import (
+    ConflictError,
+    ForbiddenError,
+    JudgeError,
+    NotFoundError,
+)
+from models.db import User
+from sessions.chat_repository import ActionLogRepository
+from sessions.repository import SessionRepository
+
+router = APIRouter(tags=["communication-evaluation"])
+
+
+def get_session_repo(db: AsyncSession = Depends(get_db)) -> SessionRepository:
+    return SessionRepository(db)
+
+
+def get_log_repo(db: AsyncSession = Depends(get_db)) -> ActionLogRepository:
+    return ActionLogRepository(db)
+
+
+def get_comm_eval_repo(
+    db: AsyncSession = Depends(get_db),
+) -> CommunicationEvaluationRepository:
+    return CommunicationEvaluationRepository(db)
+
+
+@router.post(
+    "/{session_id}/communication-evaluation",
+    response_model=CommunicationEvaluationResponse,
+)
+async def trigger_communication_evaluation(
+    session_id: str,
+    current_user: User = Depends(get_current_user),
+    session_repo: SessionRepository = Depends(get_session_repo),
+    log_repo: ActionLogRepository = Depends(get_log_repo),
+    comm_eval_repo: CommunicationEvaluationRepository = Depends(get_comm_eval_repo),
+    provider: AIProvider = Depends(get_judge_provider),
+) -> CommunicationEvaluationResponse:
+    try:
+        return await service.run_communication_evaluation(
+            session_id,
+            current_user,
+            session_repo,
+            log_repo,
+            comm_eval_repo,
+            provider,
+        )
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    except ForbiddenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
+    except ConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(exc)
+        ) from exc
+    except JudgeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)
+        ) from exc
+
+
+@router.get(
+    "/{session_id}/communication-evaluation",
+    response_model=CommunicationEvaluationResponse,
+)
+async def get_communication_evaluation(
+    session_id: str,
+    current_user: User = Depends(get_current_user),
+    session_repo: SessionRepository = Depends(get_session_repo),
+    comm_eval_repo: CommunicationEvaluationRepository = Depends(get_comm_eval_repo),
+) -> CommunicationEvaluationResponse:
+    try:
+        return await service.get_communication_evaluation(
+            session_id, current_user, session_repo, comm_eval_repo
+        )
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    except ForbiddenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
+    except ConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(exc)
+        ) from exc

--- a/backend/communication_eval/service.py
+++ b/backend/communication_eval/service.py
@@ -1,0 +1,104 @@
+import config
+from communication_eval.judge import run_judge
+from communication_eval.repository import CommunicationEvaluationRepository
+from communication_eval.response import (
+    CommunicationCriterionResponse,
+    CommunicationEvaluationResponse,
+)
+from core.provider import AIProvider
+from exceptions.auth_exceptions import ConflictError, ForbiddenError, NotFoundError
+from models.db import CaseSession, CommunicationEvaluation, User
+from sessions.chat_repository import ActionLogRepository
+from sessions.repository import SessionRepository
+
+
+def _can_read_evaluation(session: CaseSession, user: User) -> bool:
+    return user.role in ("educator", "admin") or session.user_id == user.id
+
+
+def _to_response(
+    evaluation: CommunicationEvaluation,
+) -> CommunicationEvaluationResponse:
+    return CommunicationEvaluationResponse(
+        session_id=evaluation.session_id,
+        model=evaluation.model,
+        prompt_version=evaluation.prompt_version,
+        total_score=evaluation.total_score,
+        created_at=evaluation.created_at,
+        criteria=[
+            CommunicationCriterionResponse(
+                criterion=item.criterion,
+                score=item.score,
+                rationale=item.rationale,
+                quote=item.quote,
+            )
+            for item in evaluation.criteria
+        ],
+    )
+
+
+async def _get_session_for_access(
+    session_id: str,
+    current_user: User,
+    session_repo: SessionRepository,
+) -> CaseSession:
+    session = await session_repo.get_by_session_id(session_id)
+    if session is None:
+        raise NotFoundError(f"Session '{session_id}' not found")
+    if not _can_read_evaluation(session, current_user):
+        raise ForbiddenError("You do not have access to this evaluation")
+    return session
+
+
+def _require_finished(session: CaseSession) -> None:
+    if session.status != "completed":
+        raise ConflictError("Session is not finished")
+
+
+def _resolved_model_name(provider: AIProvider) -> str:
+    model_name = getattr(provider, "model_name", None)
+    if isinstance(model_name, str):
+        return model_name
+    return config.COMMUNICATION_EVAL_MODEL
+
+
+async def run_communication_evaluation(
+    session_id: str,
+    current_user: User,
+    session_repo: SessionRepository,
+    log_repo: ActionLogRepository,
+    comm_eval_repo: CommunicationEvaluationRepository,
+    provider: AIProvider,
+) -> CommunicationEvaluationResponse:
+    session = await _get_session_for_access(session_id, current_user, session_repo)
+    _require_finished(session)
+
+    existing = await comm_eval_repo.get_by_session_id(session_id)
+    if existing is not None:
+        return _to_response(existing)
+
+    logs = await log_repo.get_history(session_id)
+    judge_output, total_score = await run_judge(logs, provider)
+    evaluation = await comm_eval_repo.create(
+        session_id=session_id,
+        model=_resolved_model_name(provider),
+        prompt_version=config.COMMUNICATION_EVAL_PROMPT_VERSION,
+        total_score=total_score,
+        judge_output=judge_output,
+    )
+    return _to_response(evaluation)
+
+
+async def get_communication_evaluation(
+    session_id: str,
+    current_user: User,
+    session_repo: SessionRepository,
+    comm_eval_repo: CommunicationEvaluationRepository,
+) -> CommunicationEvaluationResponse:
+    session = await _get_session_for_access(session_id, current_user, session_repo)
+    _require_finished(session)
+
+    evaluation = await comm_eval_repo.get_by_session_id(session_id)
+    if evaluation is None:
+        raise ConflictError("Communication evaluation not yet available")
+    return _to_response(evaluation)

--- a/backend/config.py
+++ b/backend/config.py
@@ -39,6 +39,13 @@ EVALUATION_AUTO_SCORE: bool = (
     os.environ.get("EVALUATION_AUTO_SCORE", "true").lower() == "true"
 )
 
+COMMUNICATION_EVAL_PROMPT_VERSION: str = os.environ.get(
+    "COMMUNICATION_EVAL_PROMPT_VERSION", "v1"
+)
+COMMUNICATION_EVAL_MODEL: str = (
+    os.environ.get("COMMUNICATION_EVAL_MODEL") or OPENAI_MODEL
+)
+
 ADMIN_USERNAME: str = os.environ.get("ADMIN_USERNAME", "admin")
 ADMIN_EMAIL: str = os.environ.get("ADMIN_EMAIL", "admin@example.com")
 ADMIN_PASSWORD: str = os.environ.get("ADMIN_PASSWORD", "changeme")

--- a/backend/core/mock_provider.py
+++ b/backend/core/mock_provider.py
@@ -1,5 +1,6 @@
 """Deterministic mock for CI — exercises injection / tone / memory paths."""
 
+import json
 import re
 
 _INJECTION = (
@@ -14,6 +15,44 @@ _INJECTION = (
 _DEFAULT = "I don't know, doc — it just hurts something awful."
 _REFUSAL = (
     "I'm the patient; I don't know about that stuff. Can we talk about my symptoms?"
+)
+
+_JUDGE_MARKER = "COMMUNICATION_JUDGE_V1"
+_MOCK_JUDGE_RESPONSE = json.dumps(
+    {
+        "criteria": [
+            {
+                "criterion": "open_ended_questions",
+                "score": 4,
+                "rationale": "Used open-ended questions to explore symptoms.",
+                "quote": "Can you tell me more about the pain?",
+            },
+            {
+                "criterion": "empathy",
+                "score": 4,
+                "rationale": "Acknowledged patient concern.",
+                "quote": "I understand this is worrying for you.",
+            },
+            {
+                "criterion": "structured_history",
+                "score": 3,
+                "rationale": "Partially structured the history.",
+                "quote": "When did the pain start?",
+            },
+            {
+                "criterion": "closing_the_loop",
+                "score": 3,
+                "rationale": "Some summarising but incomplete.",
+                "quote": "So the pain started this morning.",
+            },
+            {
+                "criterion": "no_leading_questions",
+                "score": 5,
+                "rationale": "Avoided leading questions.",
+                "quote": "Where does it hurt?",
+            },
+        ]
+    }
 )
 
 
@@ -32,19 +71,30 @@ def _system_raw(messages: list[dict[str, str]]) -> str:
 
 
 def _all_user_texts(messages: list[dict[str, str]]) -> str:
-    return " ".join(
-        m.get("content") or "" for m in messages if m.get("role") == "user"
-    )
+    return " ".join(m.get("content") or "" for m in messages if m.get("role") == "user")
 
 
 class MockProvider:
-    async def complete(self, messages: list[dict[str, str]]) -> str:
+    @property
+    def model_name(self) -> str:
+        return "mock"
+
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        temperature: float | None = None,
+        json_mode: bool = False,
+    ) -> str:
+        raw = _system_raw(messages)
+        if _JUDGE_MARKER in raw:
+            return _MOCK_JUDGE_RESPONSE
+
         last = _last_user(messages)
         for needle in _INJECTION:
             if needle in last:
                 return _REFUSAL
 
-        raw = _system_raw(messages)
         all_u = _all_user_texts(messages)
         tid_m = re.search(r"SESSION_TONE_ID:\s*(\S+)", raw, flags=re.IGNORECASE)
         tone_id = (tid_m.group(1) if tid_m else "").lower().replace(" ", "_")

--- a/backend/core/openai_provider.py
+++ b/backend/core/openai_provider.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import openai
 
 
@@ -21,11 +23,47 @@ class OpenAIProvider:
         self._model = model
         self._max_tokens = max_tokens
 
-    async def complete(self, messages: list[dict[str, str]]) -> str:
-        response = await self._client.chat.completions.create(
-            model=self._model,
-            messages=messages,  # type: ignore[arg-type]
-            max_tokens=self._max_tokens,
-        )
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        temperature: float | None = None,
+        json_mode: bool = False,
+    ) -> str:
+        typed_messages = cast(Any, messages)
+        json_format = cast(Any, {"type": "json_object"})
+
+        if temperature is not None and json_mode:
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                messages=typed_messages,
+                max_tokens=self._max_tokens,
+                temperature=temperature,
+                response_format=json_format,
+            )
+        elif temperature is not None:
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                messages=typed_messages,
+                max_tokens=self._max_tokens,
+                temperature=temperature,
+            )
+        elif json_mode:
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                messages=typed_messages,
+                max_tokens=self._max_tokens,
+                response_format=json_format,
+            )
+        else:
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                messages=typed_messages,
+                max_tokens=self._max_tokens,
+            )
         content = response.choices[0].message.content
         return content or ""

--- a/backend/core/provider.py
+++ b/backend/core/provider.py
@@ -3,7 +3,13 @@ from typing import Protocol, TypeAlias, runtime_checkable
 
 @runtime_checkable
 class AIProvider(Protocol):
-    async def complete(self, messages: list[dict[str, str]]) -> str: ...
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        temperature: float | None = None,
+        json_mode: bool = False,
+    ) -> str: ...
 
 
 BaseAIProvider: TypeAlias = AIProvider

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -37,6 +37,14 @@ def get_auth_service(
 
 
 def get_ai_provider() -> AIProvider:
+    return _build_openai_provider(config.OPENAI_MODEL)
+
+
+def get_judge_provider() -> AIProvider:
+    return _build_openai_provider(config.COMMUNICATION_EVAL_MODEL)
+
+
+def _build_openai_provider(model: str) -> AIProvider:
     name = config.resolved_ai_provider()
     if name == "mock":
         return MockProvider()
@@ -47,7 +55,7 @@ def get_ai_provider() -> AIProvider:
         extra["X-Title"] = config.OPENROUTER_APP_NAME.strip()
     return OpenAIProvider(
         api_key=config.OPENAI_API_KEY,
-        model=config.OPENAI_MODEL,
+        model=model,
         base_url=config.OPENAI_BASE_URL,
         default_headers=extra or None,
         max_tokens=config.OPENAI_MAX_TOKENS,

--- a/backend/exceptions/auth_exceptions.py
+++ b/backend/exceptions/auth_exceptions.py
@@ -16,3 +16,7 @@ class NotFoundError(Exception):
 
 class ForbiddenError(Exception):
     pass
+
+
+class JudgeError(Exception):
+    pass

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -370,3 +370,47 @@ class EvaluationFinding(Base):
     evaluation: Mapped[Evaluation] = relationship(
         "Evaluation", back_populates="findings"
     )
+
+
+# ---------------------------------------------------------------------------
+# Communication Evaluation
+# ---------------------------------------------------------------------------
+
+
+class CommunicationEvaluation(Base):
+    __tablename__ = "communication_evaluations"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    session_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("case_sessions.session_id"),
+        unique=True,
+        nullable=False,
+    )
+    model: Mapped[str] = mapped_column(String, nullable=False)
+    prompt_version: Mapped[str] = mapped_column(String, nullable=False)
+    total_score: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    criteria: Mapped[list["CommunicationCriterion"]] = relationship(
+        "CommunicationCriterion",
+        back_populates="evaluation",
+        cascade="all, delete-orphan",
+    )
+
+
+class CommunicationCriterion(Base):
+    __tablename__ = "communication_criteria"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    evaluation_id: Mapped[str] = mapped_column(
+        String, ForeignKey("communication_evaluations.id"), nullable=False
+    )
+    criterion: Mapped[str] = mapped_column(String, nullable=False)
+    score: Mapped[int] = mapped_column(Integer, nullable=False)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False)
+    quote: Mapped[str] = mapped_column(Text, nullable=False)
+    evaluation: Mapped[CommunicationEvaluation] = relationship(
+        "CommunicationEvaluation", back_populates="criteria"
+    )

--- a/backend/sessions/router.py
+++ b/backend/sessions/router.py
@@ -30,9 +30,11 @@ from sessions.response import (
 )
 from evaluation.router import router as evaluation_router
 from evaluation.repository import EvaluationRepository
+from communication_eval.router import router as communication_eval_router
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
 router.include_router(evaluation_router)
+router.include_router(communication_eval_router)
 
 
 def get_session_repo(db: AsyncSession = Depends(get_db)) -> SessionRepository:

--- a/backend/tests/test_communication_evaluation.py
+++ b/backend/tests/test_communication_evaluation.py
@@ -1,0 +1,408 @@
+"""Integration tests for communication evaluation API (#69)."""
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+import models.database as database
+from communication_eval.judge_schemas import JudgeCriterionOutput, compute_total_score
+from dependencies import get_judge_provider
+from models.db import ActionLog, ClinicalCase, User
+from server import app
+from services.utils.auth import hash_password
+
+_TEST_PASSWORD = "secret123"
+_COMM_EVAL_PATH = "/sessions/{session_id}/communication-evaluation"
+
+
+def _minimal_case(case_id: str = "comm_eval_case_001") -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "title": "Acute chest pain",
+        "language": "en",
+        "difficulty": "medium",
+        "specialty": "emergency_medicine",
+        "tags": ["chest_pain"],
+        "age": 54,
+        "sex": "male",
+        "persona": "Worried delivery driver.",
+        "tone_presets": ["neutral"],
+        "chief_complaint": "Chest pain",
+        "history_of_present_illness": "Substernal pressure for 45 minutes.",
+        "key_history_points": {
+            "must_ask": ["Onset and duration"],
+            "nice_to_ask": ["Recent exertion"],
+            "red_flags": ["Syncope"],
+        },
+        "final_diagnosis": "STEMI",
+        "differential": ["STEMI", "Unstable angina"],
+        "severity_or_stage": None,
+        "investigations": {
+            "catalog_hints": ["ECG"],
+            "expected": {
+                "must_order": ["ECG"],
+                "optional": [],
+                "should_not_order": [],
+            },
+            "results": [
+                {
+                    "test_name": "ECG",
+                    "result_type": "text_report",
+                    "value": "ST elevation.",
+                    "unit": None,
+                    "reference_range": None,
+                }
+            ],
+        },
+        "management": {
+            "diagnostic_plan": ["Immediate ECG"],
+            "treatment_plan": ["Activate cath lab"],
+            "contraindications": [],
+            "follow_up": [],
+        },
+        "scoring": {
+            "weight_diagnosis": 0.35,
+            "weight_diagnostics": 0.25,
+            "weight_treatment": 0.30,
+            "weight_safety": 0.10,
+            "acceptable_answers": [{"field": "final_diagnosis", "answer": "STEMI"}],
+            "critical_safety_errors": [],
+        },
+    }
+
+
+def _publish_case(case_id: str) -> None:
+    async def _run() -> None:
+        session_factory = cast(
+            async_sessionmaker[AsyncSession],
+            database._TestSessionLocal,  # type: ignore[attr-defined]
+        )
+        async with session_factory() as session:
+            await session.execute(
+                update(ClinicalCase)
+                .where(ClinicalCase.case_id == case_id)
+                .values(status="published")
+            )
+            await session.commit()
+
+    asyncio.run(_run())
+
+
+def _insert_user(username: str, role: str) -> None:
+    async def _run() -> None:
+        session_factory = cast(
+            async_sessionmaker[AsyncSession],
+            database._TestSessionLocal,  # type: ignore[attr-defined]
+        )
+        async with session_factory() as session:
+            session.add(
+                User(
+                    id=str(uuid.uuid4()),
+                    username=username,
+                    email=f"{username}@example.com",
+                    hashed_password=hash_password(_TEST_PASSWORD),
+                    role=role,
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_run())
+
+
+def _auth_headers(client: TestClient, username: str) -> dict[str, str]:
+    tokens: dict[str, str] = client.post(
+        "/auth/login",
+        data={"username": username, "password": _TEST_PASSWORD},
+    ).json()
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+@pytest.fixture()
+def comm_eval_case_id(client: TestClient, educator_headers: dict[str, str]) -> str:
+    payload = _minimal_case()
+    r = client.post("/cases", json=payload, headers=educator_headers)
+    assert r.status_code == 201
+    case_id: str = r.json()["case_id"]
+    _publish_case(case_id)
+    return case_id
+
+
+def _start_and_finish(
+    client: TestClient,
+    headers: dict[str, str],
+    case_id: str,
+) -> str:
+    start = client.post("/sessions/start", json={"case_id": case_id}, headers=headers)
+    assert start.status_code == 201
+    session_id: str = start.json()["session_id"]
+
+    chat = client.post(
+        f"/sessions/{session_id}/chat",
+        json={"message": "Where does it hurt?"},
+        headers=headers,
+    )
+    assert chat.status_code == 200
+
+    patch = client.patch(
+        f"/sessions/{session_id}/conclusions",
+        json={"final_diagnosis": "STEMI"},
+        headers=headers,
+    )
+    assert patch.status_code == 200
+
+    finish = client.post(f"/sessions/{session_id}/finish", headers=headers)
+    assert finish.status_code == 200
+    return session_id
+
+
+class _InvalidJsonProvider:
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        temperature: float | None = None,
+        json_mode: bool = False,
+    ) -> str:
+        return "not json"
+
+
+def test_owner_post_communication_evaluation_after_finish(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    session_id = _start_and_finish(client, learner_headers, comm_eval_case_id)
+    r = client.post(
+        _COMM_EVAL_PATH.format(session_id=session_id),
+        headers=learner_headers,
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["session_id"] == session_id
+    assert body["model"] == "mock"
+    assert body["prompt_version"] == "v1"
+    assert body["total_score"] == 76.0
+    assert len(body["criteria"]) == 5
+    assert {item["criterion"] for item in body["criteria"]} == {
+        "open_ended_questions",
+        "empathy",
+        "structured_history",
+        "closing_the_loop",
+        "no_leading_questions",
+    }
+
+
+def test_post_idempotent_returns_existing_record(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    session_id = _start_and_finish(client, learner_headers, comm_eval_case_id)
+    path = _COMM_EVAL_PATH.format(session_id=session_id)
+    first = client.post(path, headers=learner_headers)
+    second = client.post(path, headers=learner_headers)
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["created_at"] == second.json()["created_at"]
+    assert first.json()["total_score"] == second.json()["total_score"]
+
+
+def test_owner_get_communication_evaluation(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    session_id = _start_and_finish(client, learner_headers, comm_eval_case_id)
+    path = _COMM_EVAL_PATH.format(session_id=session_id)
+    client.post(path, headers=learner_headers)
+    r = client.get(path, headers=learner_headers)
+    assert r.status_code == 200
+    assert r.json()["session_id"] == session_id
+
+
+def test_non_owner_post_forbidden(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    session_id = _start_and_finish(client, learner_headers, comm_eval_case_id)
+    _insert_user("other_learner_comm", "learner")
+    other_headers = _auth_headers(client, "other_learner_comm")
+    r = client.post(
+        _COMM_EVAL_PATH.format(session_id=session_id),
+        headers=other_headers,
+    )
+    assert r.status_code == 403
+
+
+def test_admin_post_any_session(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    admin_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    session_id = _start_and_finish(client, learner_headers, comm_eval_case_id)
+    r = client.post(
+        _COMM_EVAL_PATH.format(session_id=session_id),
+        headers=admin_headers,
+    )
+    assert r.status_code == 200
+
+
+def test_educator_get_any_session(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    educator_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    session_id = _start_and_finish(client, learner_headers, comm_eval_case_id)
+    path = _COMM_EVAL_PATH.format(session_id=session_id)
+    client.post(path, headers=learner_headers)
+    r = client.get(path, headers=educator_headers)
+    assert r.status_code == 200
+
+
+def test_unfinished_session_returns_409(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    start = client.post(
+        "/sessions/start",
+        json={"case_id": comm_eval_case_id},
+        headers=learner_headers,
+    )
+    session_id: str = start.json()["session_id"]
+    r = client.post(
+        _COMM_EVAL_PATH.format(session_id=session_id),
+        headers=learner_headers,
+    )
+    assert r.status_code == 409
+
+
+def test_missing_session_returns_404(
+    client: TestClient,
+    learner_headers: dict[str, str],
+) -> None:
+    r = client.post(
+        _COMM_EVAL_PATH.format(session_id="nonexistent-session-id"),
+        headers=learner_headers,
+    )
+    assert r.status_code == 404
+
+
+def test_get_before_evaluation_returns_409(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    session_id = _start_and_finish(client, learner_headers, comm_eval_case_id)
+    r = client.get(
+        _COMM_EVAL_PATH.format(session_id=session_id),
+        headers=learner_headers,
+    )
+    assert r.status_code == 409
+
+
+def test_mock_provider_deterministic_scores(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    session_id = _start_and_finish(client, learner_headers, comm_eval_case_id)
+    path = _COMM_EVAL_PATH.format(session_id=session_id)
+    first = client.post(path, headers=learner_headers).json()
+    second = client.post(path, headers=learner_headers).json()
+    assert first["total_score"] == second["total_score"] == 76.0
+    assert first["criteria"] == second["criteria"]
+
+
+def test_invalid_judge_json_returns_502_and_does_not_persist(
+    client: TestClient,
+    learner_headers: dict[str, str],
+    comm_eval_case_id: str,
+) -> None:
+    session_id = _start_and_finish(client, learner_headers, comm_eval_case_id)
+    path = _COMM_EVAL_PATH.format(session_id=session_id)
+    app.dependency_overrides[get_judge_provider] = lambda: _InvalidJsonProvider()
+    try:
+        r = client.post(path, headers=learner_headers)
+        assert r.status_code == 502
+        get_r = client.get(path, headers=learner_headers)
+        assert get_r.status_code == 409
+    finally:
+        app.dependency_overrides.pop(get_judge_provider, None)
+
+
+def test_compute_total_score() -> None:
+    criteria = [
+        JudgeCriterionOutput(
+            criterion="open_ended_questions",
+            score=4,
+            rationale="ok",
+            quote="q",
+        ),
+        JudgeCriterionOutput(
+            criterion="empathy",
+            score=4,
+            rationale="ok",
+            quote="q",
+        ),
+        JudgeCriterionOutput(
+            criterion="structured_history",
+            score=3,
+            rationale="ok",
+            quote="q",
+        ),
+        JudgeCriterionOutput(
+            criterion="closing_the_loop",
+            score=3,
+            rationale="ok",
+            quote="q",
+        ),
+        JudgeCriterionOutput(
+            criterion="no_leading_questions",
+            score=5,
+            rationale="ok",
+            quote="q",
+        ),
+    ]
+    assert compute_total_score(criteria) == 76.0
+
+
+def test_build_transcript_filters_non_chat_roles() -> None:
+    from communication_eval.judge import build_transcript
+
+    logs = [
+        ActionLog(
+            id="1",
+            session_id="s1",
+            role="system",
+            content="TEST_ORDERED:ECG",
+            created_at=datetime.now(timezone.utc),
+        ),
+        ActionLog(
+            id="2",
+            session_id="s1",
+            role="user",
+            content="Where does it hurt?",
+            created_at=datetime.now(timezone.utc),
+        ),
+        ActionLog(
+            id="3",
+            session_id="s1",
+            role="assistant",
+            content="In my chest.",
+            created_at=datetime.now(timezone.utc),
+        ),
+    ]
+    transcript = build_transcript(logs)
+    assert "TEST_ORDERED" not in transcript
+    assert "1. Doctor: Where does it hurt?" in transcript
+    assert "2. Patient: In my chest." in transcript


### PR DESCRIPTION
## Description

Adds LLM-as-judge communication scoring over the persisted chat log for finished sessions. Exposes POST/GET endpoints to trigger and read per-criterion communication scores for the debrief flow.

## Related Issue

- Closes #69

## Subtasks Checklist

- [x] `communication_eval` module (judge pipeline, repository, service, router)
- [x] DB models `CommunicationEvaluation` / `CommunicationCriterion`
- [x] Alembic migration `003_add_communication_evaluations`
- [x] Extend `AIProvider` with `temperature` / `json_mode`; dedicated `get_judge_provider()` with `COMMUNICATION_EVAL_MODEL`
- [x] Integration tests (`test_communication_evaluation.py`, 13 tests)

## Verification of Acceptance Criteria

- [x] Alembic migration for `communication_evaluations` and `communication_criteria` (reversible `downgrade`)
  - `backend/alembic/versions/003_add_communication_evaluations.py`
- [x] POST `/sessions/{id}/communication-evaluation` is idempotent per `session_id`
  - `test_post_idempotent_returns_existing_record`
- [x] Both endpoints visible in Swagger UI at `/docs`
  - Paths: `/sessions/{session_id}/communication-evaluation` (no `/v1`, same convention as #63)
- [x] Re-running judge on same transcript yields identical scores (mock provider, temperature=0)
  - `test_mock_provider_deterministic_scores`
- [x] Malformed JSON → 502, no DB corruption
  - `test_invalid_judge_json_returns_502_and_does_not_persist`
- [x] Auth: owner 200, non-owner 403, admin 200, educator 200, unfinished 409, missing 404
  - Covered in `test_communication_evaluation.py`

## Test plan

- [x] `uv run pytest tests/test_communication_evaluation.py -q`
- [x] `uv run pytest -q` (166 tests)
- [x] `uv run mypy --strict .`
- [x] Manual: finish session → POST communication-evaluation → GET → check criteria in Swagger `/docs`

## Notes

- Endpoints without `/v1` prefix (aligned with existing `/sessions/{id}/scores`).
- RBAC matches rules-based evaluation: owner, educator, admin.
- `openapi.json` not updated (frontend out of scope for this backend task).

### PR Checklist

- [x] I have linked the related issue.
- [x] My code follows the project's style guidelines.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests pass.