### PR TITLE
Communication evaluation frontend (#72)

### DIFF
--- a/backend/alembic/versions/003_communication_eval.py
+++ b/backend/alembic/versions/003_communication_eval.py
@@ -1,6 +1,6 @@
 """Add communication_evaluations and communication_criteria tables.
 
-Revision ID: 003_add_communication_evaluations
+Revision ID: 003_communication_eval
 Revises: 002_add_last_activity_at
 Create Date: 2026-06-19
 
@@ -11,7 +11,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "003_add_communication_evaluations"
+revision: str = "003_communication_eval"
 down_revision: Union[str, Sequence[str], None] = "002_add_last_activity_at"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/frontend/lib/app/app.dart
+++ b/frontend/lib/app/app.dart
@@ -4,6 +4,7 @@ import 'package:frontend/common/theme/app_theme.dart';
 import 'package:frontend/domains/admin/admin_repository.dart';
 import 'package:frontend/domains/auth/auth_repository.dart';
 import 'package:frontend/domains/cases/case_repository.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
 
@@ -20,6 +21,7 @@ class _VirtualAiPatientAppState extends State<VirtualAiPatientApp> {
   late final CaseRepository _caseRepository;
   late final SessionRepository _sessionRepository;
   late final EvaluationRepository _evaluationRepository;
+  late final CommunicationRepository _communicationRepository;
   Widget? _home;
 
   @override
@@ -37,6 +39,8 @@ class _VirtualAiPatientAppState extends State<VirtualAiPatientApp> {
         SessionRepository(openapi: _authRepository.openapiClient);
     _evaluationRepository =
         EvaluationRepository(openapi: _authRepository.openapiClient);
+    _communicationRepository =
+        CommunicationRepository(openapi: _authRepository.openapiClient);
     _bootstrap();
   }
 
@@ -52,6 +56,7 @@ class _VirtualAiPatientAppState extends State<VirtualAiPatientApp> {
               caseRepository: _caseRepository,
               sessionRepository: _sessionRepository,
               evaluationRepository: _evaluationRepository,
+              communicationRepository: _communicationRepository,
               adminRepository: _adminRepository,
             )
           : AppSessionRouter.homeForSession(
@@ -60,6 +65,7 @@ class _VirtualAiPatientAppState extends State<VirtualAiPatientApp> {
               caseRepository: _caseRepository,
               sessionRepository: _sessionRepository,
               evaluationRepository: _evaluationRepository,
+              communicationRepository: _communicationRepository,
               adminRepository: _adminRepository,
             );
     });

--- a/frontend/lib/app/app_session_router.dart
+++ b/frontend/lib/app/app_session_router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frontend/domains/admin/admin_repository.dart';
 import 'package:frontend/domains/auth/auth_repository.dart';
 import 'package:frontend/domains/cases/case_repository.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
 import 'package:frontend/features/auth/presentation/login_screen.dart';
@@ -17,6 +18,7 @@ class AppSessionRouter {
     required CaseRepositoryContract caseRepository,
     required SessionRepositoryContract sessionRepository,
     required EvaluationRepositoryContract evaluationRepository,
+    required CommunicationRepositoryContract communicationRepository,
     AdminRepositoryContract? adminRepository,
   }) {
     return LoginScreen(
@@ -24,6 +26,7 @@ class AppSessionRouter {
       caseRepository: caseRepository,
       sessionRepository: sessionRepository,
       evaluationRepository: evaluationRepository,
+      communicationRepository: communicationRepository,
       adminRepository: adminRepository,
     );
   }
@@ -34,6 +37,7 @@ class AppSessionRouter {
     required CaseRepositoryContract caseRepository,
     required SessionRepositoryContract sessionRepository,
     required EvaluationRepositoryContract evaluationRepository,
+    required CommunicationRepositoryContract communicationRepository,
     AdminRepositoryContract? adminRepository,
   }) {
     LoginScreen createLoginScreen() => loginScreen(
@@ -41,6 +45,7 @@ class AppSessionRouter {
           caseRepository: caseRepository,
           sessionRepository: sessionRepository,
           evaluationRepository: evaluationRepository,
+          communicationRepository: communicationRepository,
           adminRepository: adminRepository,
         );
     if (session.user.role == 'admin' && adminRepository != null) {
@@ -56,6 +61,7 @@ class AppSessionRouter {
       caseRepository: caseRepository,
       sessionRepository: sessionRepository,
       evaluationRepository: evaluationRepository,
+      communicationRepository: communicationRepository,
       authRepository: authRepository,
       adminRepository: adminRepository,
       buildLoginPage: createLoginScreen,

--- a/frontend/lib/domains/evaluation/communication_repository.dart
+++ b/frontend/lib/domains/evaluation/communication_repository.dart
@@ -1,0 +1,42 @@
+import 'package:frontend/network/openapi.dart' as generated;
+
+abstract class CommunicationRepositoryContract {
+  Future<generated.CommunicationEvaluationResponse> getCommunicationEvaluation({
+    required String sessionId,
+  });
+
+  Future<generated.CommunicationEvaluationResponse>
+      triggerCommunicationEvaluation({
+    required String sessionId,
+  });
+}
+
+class CommunicationRepository implements CommunicationRepositoryContract {
+  CommunicationRepository({required generated.Openapi openapi})
+      : _api = openapi.getCommunicationEvaluationApi();
+
+  final generated.CommunicationEvaluationApi _api;
+
+  @override
+  Future<generated.CommunicationEvaluationResponse> getCommunicationEvaluation({
+    required String sessionId,
+  }) async {
+    final response = await _api
+        .getCommunicationEvaluationSessionsSessionIdCommunicationEvaluationGet(
+      sessionId: sessionId,
+    );
+    return response.data!;
+  }
+
+  @override
+  Future<generated.CommunicationEvaluationResponse>
+      triggerCommunicationEvaluation({
+    required String sessionId,
+  }) async {
+    final response = await _api
+        .triggerCommunicationEvaluationSessionsSessionIdCommunicationEvaluationPost(
+      sessionId: sessionId,
+    );
+    return response.data!;
+  }
+}

--- a/frontend/lib/features/auth/presentation/login_screen.dart
+++ b/frontend/lib/features/auth/presentation/login_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frontend/domains/admin/admin_repository.dart';
 import 'package:frontend/domains/auth/auth_repository.dart';
 import 'package:frontend/domains/cases/case_repository.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
 import 'package:frontend/features/auth/presentation/dialogs/reset_password_dialog.dart';
@@ -21,6 +22,7 @@ class LoginScreen extends StatefulWidget {
     required this.caseRepository,
     required this.sessionRepository,
     required this.evaluationRepository,
+    required this.communicationRepository,
     this.adminRepository,
   });
 
@@ -28,6 +30,7 @@ class LoginScreen extends StatefulWidget {
   final CaseRepositoryContract caseRepository;
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
+  final CommunicationRepositoryContract communicationRepository;
   final AdminRepositoryContract? adminRepository;
 
   @override
@@ -59,6 +62,7 @@ class _LoginScreenState extends State<LoginScreen> {
         caseRepository: widget.caseRepository,
         sessionRepository: widget.sessionRepository,
         evaluationRepository: widget.evaluationRepository,
+        communicationRepository: widget.communicationRepository,
         adminRepository: widget.adminRepository,
       );
       Navigator.of(context).pushReplacement(

--- a/frontend/lib/features/cases/presentation/case_briefing_screen.dart
+++ b/frontend/lib/features/cases/presentation/case_briefing_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
 import 'package:frontend/domains/sessions/session_start_conflict.dart';
@@ -15,11 +16,13 @@ class CaseBriefingScreen extends StatefulWidget {
     required this.caseItem,
     required this.sessionRepository,
     required this.evaluationRepository,
+    required this.communicationRepository,
   });
 
   final generated.CaseResponse caseItem;
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
+  final CommunicationRepositoryContract communicationRepository;
 
   @override
   State<CaseBriefingScreen> createState() => _CaseBriefingScreenState();
@@ -42,6 +45,7 @@ class _CaseBriefingScreenState extends State<CaseBriefingScreen> {
             sessionId: res.sessionId,
             sessionRepository: widget.sessionRepository,
             evaluationRepository: widget.evaluationRepository,
+            communicationRepository: widget.communicationRepository,
           ),
         ),
       );
@@ -55,6 +59,7 @@ class _CaseBriefingScreenState extends State<CaseBriefingScreen> {
           conflict: conflict,
           sessionRepository: widget.sessionRepository,
           evaluationRepository: widget.evaluationRepository,
+          communicationRepository: widget.communicationRepository,
         );
         return;
       }

--- a/frontend/lib/features/cases/presentation/case_library_screen.dart
+++ b/frontend/lib/features/cases/presentation/case_library_screen.dart
@@ -6,6 +6,7 @@ import 'package:frontend/common/widgets/app_page_footer.dart';
 import 'package:frontend/domains/admin/admin_repository.dart';
 import 'package:frontend/domains/auth/auth_repository.dart';
 import 'package:frontend/domains/cases/case_repository.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
 import 'package:frontend/features/admin/presentation/admin_sessions_dashboard_screen.dart';
@@ -25,6 +26,7 @@ class CaseLibraryScreen extends StatefulWidget {
     required this.caseRepository,
     required this.sessionRepository,
     required this.evaluationRepository,
+    required this.communicationRepository,
     required this.authRepository,
     required this.adminRepository,
     required this.buildLoginPage,
@@ -34,6 +36,7 @@ class CaseLibraryScreen extends StatefulWidget {
   final CaseRepositoryContract caseRepository;
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
+  final CommunicationRepositoryContract communicationRepository;
   final AuthRepositoryContract authRepository;
   final AdminRepositoryContract? adminRepository;
   final Widget Function() buildLoginPage;
@@ -87,6 +90,7 @@ class _CaseLibraryScreenState extends State<CaseLibraryScreen> {
       context: context,
       sessionRepository: widget.sessionRepository,
       evaluationRepository: widget.evaluationRepository,
+      communicationRepository: widget.communicationRepository,
     );
   }
 
@@ -201,6 +205,7 @@ class _CaseLibraryScreenState extends State<CaseLibraryScreen> {
                         caseItem: c,
                         sessionRepository: widget.sessionRepository,
                         evaluationRepository: widget.evaluationRepository,
+                        communicationRepository: widget.communicationRepository,
                       ),
                     ),
                   );
@@ -214,6 +219,7 @@ class _CaseLibraryScreenState extends State<CaseLibraryScreen> {
                         caseItem: c,
                         sessionId: sessionId,
                         evaluationRepository: widget.evaluationRepository,
+                        communicationRepository: widget.communicationRepository,
                       ),
                     ),
                   );

--- a/frontend/lib/features/cases/presentation/case_simulation_screen.dart
+++ b/frontend/lib/features/cases/presentation/case_simulation_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:frontend/common/theme/app_colors.dart';
 import 'package:frontend/common/widgets/app_logo_mark.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_hydration.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
@@ -24,6 +25,7 @@ class CaseSimulationScreen extends StatefulWidget {
     required this.sessionId,
     required this.sessionRepository,
     required this.evaluationRepository,
+    required this.communicationRepository,
     this.initialHydration,
   });
 
@@ -31,6 +33,7 @@ class CaseSimulationScreen extends StatefulWidget {
   final String sessionId;
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
+  final CommunicationRepositoryContract communicationRepository;
   final SimulationHydration? initialHydration;
 
   @override
@@ -375,6 +378,7 @@ class _CaseSimulationScreenState extends State<CaseSimulationScreen>
           sessionId: widget.sessionId,
           sessionRepository: widget.sessionRepository,
           evaluationRepository: widget.evaluationRepository,
+          communicationRepository: widget.communicationRepository,
           initialConclusions: _savedConclusions,
         ),
       ),

--- a/frontend/lib/features/cases/presentation/simulation_conclusions_screen.dart
+++ b/frontend/lib/features/cases/presentation/simulation_conclusions_screen.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/session_completion_prefs.dart';
 import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
 import 'package:frontend/features/evaluation/presentation/debrief_screen.dart';
@@ -18,6 +19,7 @@ class SimulationConclusionsScreen extends StatefulWidget {
     required this.sessionId,
     required this.sessionRepository,
     required this.evaluationRepository,
+    required this.communicationRepository,
     this.initialConclusions,
   });
 
@@ -25,6 +27,7 @@ class SimulationConclusionsScreen extends StatefulWidget {
   final String sessionId;
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
+  final CommunicationRepositoryContract communicationRepository;
   final BuiltMap<String, JsonObject?>? initialConclusions;
 
   @override
@@ -440,6 +443,7 @@ class _SimulationConclusionsScreenState
             caseItem: widget.caseItem,
             sessionId: widget.sessionId,
             evaluationRepository: widget.evaluationRepository,
+            communicationRepository: widget.communicationRepository,
           ),
         ),
       );

--- a/frontend/lib/features/evaluation/presentation/communication_criterion_labels.dart
+++ b/frontend/lib/features/evaluation/presentation/communication_criterion_labels.dart
@@ -1,0 +1,16 @@
+/// Human-readable labels for communication rubric criterion keys from the API.
+String communicationCriterionLabel(String criterionKey) {
+  return _labels[criterionKey] ??
+      criterionKey.replaceAll('_', ' ').replaceFirstMapped(
+            RegExp(r'^\w'),
+            (m) => m.group(0)!.toUpperCase(),
+          );
+}
+
+const Map<String, String> _labels = {
+  'open_ended_questions': 'Open-ended questions',
+  'empathy': 'Empathy',
+  'structured_history': 'Structured history',
+  'closing_the_loop': 'Closing the loop',
+  'no_leading_questions': 'No leading questions',
+};

--- a/frontend/lib/features/evaluation/presentation/communication_panel.dart
+++ b/frontend/lib/features/evaluation/presentation/communication_panel.dart
@@ -1,0 +1,670 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
+import 'package:frontend/features/evaluation/presentation/communication_criterion_labels.dart';
+import 'package:frontend/network/openapi.dart' as generated;
+import 'package:google_fonts/google_fonts.dart';
+
+enum _CommLoadState {
+  loading,
+  analyzing,
+  success,
+  notFound,
+  forbidden,
+  notFinished,
+  judgeFailure,
+  unknown,
+}
+
+/// Communication coaching panel for the debrief screen (#72).
+class CommunicationPanel extends StatefulWidget {
+  const CommunicationPanel({
+    super.key,
+    required this.sessionId,
+    required this.communicationRepository,
+  });
+
+  final String sessionId;
+  final CommunicationRepositoryContract communicationRepository;
+
+  @override
+  State<CommunicationPanel> createState() => _CommunicationPanelState();
+}
+
+class _CommunicationPanelState extends State<CommunicationPanel> {
+  _CommLoadState _state = _CommLoadState.loading;
+  generated.CommunicationEvaluationResponse? _evaluation;
+  String? _errorDetail;
+  bool _triggerAttempted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _state = _CommLoadState.loading;
+      _errorDetail = null;
+    });
+    try {
+      final result =
+          await widget.communicationRepository.getCommunicationEvaluation(
+        sessionId: widget.sessionId,
+      );
+      if (!mounted) return;
+      setState(() {
+        _evaluation = result;
+        _state = _CommLoadState.success;
+      });
+    } on DioException catch (e) {
+      if (!mounted) return;
+      await _handleDioOnLoad(e);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _errorDetail = e.toString();
+        _state = _CommLoadState.unknown;
+      });
+    }
+  }
+
+  Future<void> _handleDioOnLoad(DioException e) async {
+    final code = e.response?.statusCode;
+    final detail = _detailFromDio(e);
+    if (code == 409) {
+      final d = (detail ?? '').toLowerCase();
+      if (d.contains('not yet available') && !_triggerAttempted) {
+        _triggerAttempted = true;
+        await _triggerJudge();
+        return;
+      }
+      if (d.contains('not finished')) {
+        setState(() {
+          _errorDetail = detail;
+          _state = _CommLoadState.notFinished;
+        });
+        return;
+      }
+      setState(() {
+        _errorDetail = detail;
+        _state = _CommLoadState.unknown;
+      });
+      return;
+    }
+    setState(() {
+      _errorDetail = detail;
+      _state = switch (code) {
+        403 => _CommLoadState.forbidden,
+        404 => _CommLoadState.notFound,
+        502 => _CommLoadState.judgeFailure,
+        _ => _CommLoadState.unknown,
+      };
+    });
+  }
+
+  Future<void> _triggerJudge() async {
+    setState(() => _state = _CommLoadState.analyzing);
+    try {
+      final result = await widget.communicationRepository
+          .triggerCommunicationEvaluation(sessionId: widget.sessionId);
+      if (!mounted) return;
+      setState(() {
+        _evaluation = result;
+        _state = _CommLoadState.success;
+      });
+    } on DioException catch (e) {
+      if (!mounted) return;
+      final code = e.response?.statusCode;
+      setState(() {
+        _errorDetail = _detailFromDio(e);
+        _state = switch (code) {
+          403 => _CommLoadState.forbidden,
+          404 => _CommLoadState.notFound,
+          409 => _CommLoadState.notFinished,
+          502 => _CommLoadState.judgeFailure,
+          _ => _CommLoadState.unknown,
+        };
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _errorDetail = e.toString();
+        _state = _CommLoadState.unknown;
+      });
+    }
+  }
+
+  String? _detailFromDio(DioException e) {
+    final data = e.response?.data;
+    if (data is Map && data['detail'] != null) {
+      return data['detail'].toString();
+    }
+    return e.message;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (_state) {
+      _CommLoadState.loading || _CommLoadState.analyzing => _AnalyzingBody(
+          analyzing: _state == _CommLoadState.analyzing,
+        ),
+      _CommLoadState.success => _SuccessBody(evaluation: _evaluation!),
+      _CommLoadState.notFound => _CommErrorPanel(
+          icon: Icons.search_off_rounded,
+          title: 'Session not found',
+          message: 'Communication scoring is not available for this session.',
+          detail: _errorDetail,
+          onRetry: _load,
+        ),
+      _CommLoadState.forbidden => _CommErrorPanel(
+          icon: Icons.lock_outline_rounded,
+          title: 'Access denied',
+          message: "You don't have access to this communication evaluation.",
+          detail: _errorDetail,
+          onRetry: _load,
+        ),
+      _CommLoadState.notFinished => _CommErrorPanel(
+          icon: Icons.hourglass_empty_rounded,
+          title: 'Case not finished',
+          message:
+              'Complete the case first, then return here for communication coaching.',
+          detail: _errorDetail,
+          onRetry: _load,
+        ),
+      _CommLoadState.judgeFailure => _CommErrorPanel(
+          icon: Icons.psychology_alt_outlined,
+          title: 'Communication coach unavailable',
+          message:
+              'The conversation coach could not analyze this session. Try again.',
+          detail: _errorDetail,
+          onRetry: _triggerJudge,
+          retryLabel: 'Retry analysis',
+        ),
+      _CommLoadState.unknown => _CommErrorPanel(
+          icon: Icons.error_outline_rounded,
+          title: 'Something went wrong',
+          message: 'Could not load communication coaching.',
+          detail: _errorDetail,
+          onRetry: _load,
+        ),
+    };
+  }
+}
+
+class _AnalyzingBody extends StatelessWidget {
+  const _AnalyzingBody({required this.analyzing});
+
+  final bool analyzing;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(24),
+      children: [
+        Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 720),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _HeroHeader(
+                  subtitle: analyzing
+                      ? 'Our coach is reviewing your doctor–patient conversation. This usually takes a few seconds.'
+                      : 'Checking for saved communication feedback…',
+                ),
+                const SizedBox(height: 20),
+                ...List.generate(3, (_) => const _CriterionSkeleton()),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SuccessBody extends StatelessWidget {
+  const _SuccessBody({required this.evaluation});
+
+  final generated.CommunicationEvaluationResponse evaluation;
+
+  @override
+  Widget build(BuildContext context) {
+    final total = evaluation.totalScore.toDouble();
+    return ListView(
+      padding: const EdgeInsets.all(24),
+      children: [
+        Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 720),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _HeroHeader(
+                  subtitle:
+                      'Feedback on your communication style — not clinical advice.',
+                ),
+                const SizedBox(height: 20),
+                _ScoreHero(totalScore: total),
+                const SizedBox(height: 20),
+                Text(
+                  'Rubric breakdown',
+                  style: GoogleFonts.inter(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Each criterion is scored 0–5 with a quote from your conversation.',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    color: AppColors.secondaryText,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                ...evaluation.criteria.map(
+                  (c) => Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: _CriterionCard(criterion: c),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Model ${evaluation.model} · rubric ${evaluation.promptVersion} · '
+                  '${evaluation.createdAt.toLocal()}',
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    color: AppColors.tertiaryText,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _HeroHeader extends StatelessWidget {
+  const _HeroHeader({required this.subtitle});
+
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [AppColors.heroTint, AppColors.heroTintEnd],
+        ),
+        borderRadius: BorderRadius.all(Radius.circular(12)),
+        border:
+            Border.fromBorderSide(BorderSide(color: AppColors.borderSubtle)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 44,
+            height: 44,
+            decoration: BoxDecoration(
+              color: AppColors.brandTeal.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: const Icon(
+              Icons.record_voice_over_rounded,
+              color: AppColors.brandTeal,
+              size: 24,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Communication coaching',
+                  style: GoogleFonts.inter(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 17,
+                    color: AppColors.primaryText,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  subtitle,
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    height: 1.4,
+                    color: AppColors.secondaryText,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ScoreHero extends StatelessWidget {
+  const _ScoreHero({required this.totalScore});
+
+  final double totalScore;
+
+  Color get _ringColor {
+    if (totalScore >= 80) return AppColors.brandTeal;
+    if (totalScore >= 60) return AppColors.primaryBlue;
+    return AppColors.difficultyMedium;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (totalScore / 100).clamp(0.0, 1.0);
+    return Material(
+      color: AppColors.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: const BorderSide(color: AppColors.borderSubtle),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 88,
+              height: 88,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  CircularProgressIndicator(
+                    value: progress,
+                    strokeWidth: 8,
+                    backgroundColor: AppColors.surfaceMuted,
+                    color: _ringColor,
+                  ),
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        totalScore.toStringAsFixed(0),
+                        style: GoogleFonts.inter(
+                          fontWeight: FontWeight.w800,
+                          fontSize: 22,
+                          color: _ringColor,
+                        ),
+                      ),
+                      Text(
+                        '/ 100',
+                        style: GoogleFonts.inter(
+                          fontSize: 11,
+                          color: AppColors.secondaryText,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 20),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Total communication score',
+                    style: GoogleFonts.inter(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 15,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    _scoreBandLabel(totalScore),
+                    style: GoogleFonts.inter(
+                      fontSize: 13,
+                      color: AppColors.secondaryText,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _scoreBandLabel(double score) {
+    if (score >= 80) return 'Strong rapport and interviewing skills.';
+    if (score >= 60) return 'Solid foundation with room to refine technique.';
+    return 'Focus on open questions, empathy, and structure.';
+  }
+}
+
+class _CriterionCard extends StatefulWidget {
+  const _CriterionCard({required this.criterion});
+
+  final generated.CommunicationCriterionResponse criterion;
+
+  @override
+  State<_CriterionCard> createState() => _CriterionCardState();
+}
+
+class _CriterionCardState extends State<_CriterionCard> {
+  bool _expanded = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = widget.criterion;
+    final label = communicationCriterionLabel(c.criterion);
+    return Material(
+      color: AppColors.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: const BorderSide(color: AppColors.borderSubtle),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => setState(() => _expanded = !_expanded),
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      label,
+                      style: GoogleFonts.inter(
+                        fontWeight: FontWeight.w700,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                  _ScoreDots(score: c.score),
+                  const SizedBox(width: 8),
+                  Icon(
+                    _expanded
+                        ? Icons.expand_less_rounded
+                        : Icons.expand_more_rounded,
+                    color: AppColors.tertiaryText,
+                    size: 20,
+                  ),
+                ],
+              ),
+              if (_expanded) ...[
+                const SizedBox(height: 12),
+                Text(
+                  c.rationale,
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    height: 1.45,
+                    color: AppColors.primaryText,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppColors.surfaceMuted,
+                    borderRadius: BorderRadius.circular(8),
+                    border: const Border(
+                      left: BorderSide(color: AppColors.brandTeal, width: 3),
+                    ),
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Icon(
+                        Icons.format_quote_rounded,
+                        size: 18,
+                        color: AppColors.brandTeal,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: SelectableText(
+                          c.quote.isEmpty ? '—' : c.quote,
+                          style: GoogleFonts.inter(
+                            fontSize: 13,
+                            fontStyle: FontStyle.italic,
+                            height: 1.4,
+                            color: AppColors.secondaryText,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ScoreDots extends StatelessWidget {
+  const _ScoreDots({required this.score});
+
+  final int score;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(5, (i) {
+        final filled = i < score;
+        return Container(
+          width: 10,
+          height: 10,
+          margin: const EdgeInsets.only(left: 3),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: filled ? AppColors.primaryBlue : AppColors.borderSubtle,
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class _CriterionSkeleton extends StatelessWidget {
+  const _CriterionSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Material(
+        color: AppColors.surfaceMuted,
+        borderRadius: BorderRadius.circular(12),
+        child: const SizedBox(height: 72),
+      ),
+    );
+  }
+}
+
+class _CommErrorPanel extends StatelessWidget {
+  const _CommErrorPanel({
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.detail,
+    required this.onRetry,
+    this.retryLabel = 'Retry',
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+  final String? detail;
+  final VoidCallback onRetry;
+  final String retryLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(24),
+      children: [
+        Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Material(
+              color: AppColors.surface,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+                side: const BorderSide(color: AppColors.borderSubtle),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Icon(icon, size: 40, color: AppColors.danger),
+                    const SizedBox(height: 12),
+                    Text(
+                      title,
+                      style: GoogleFonts.inter(
+                        fontWeight: FontWeight.w700,
+                        fontSize: 18,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(message, style: GoogleFonts.inter(fontSize: 14)),
+                    if (detail != null && detail!.isNotEmpty) ...[
+                      const SizedBox(height: 12),
+                      Text(
+                        detail!,
+                        style: GoogleFonts.inter(
+                          fontSize: 12,
+                          color: AppColors.secondaryText,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 20),
+                    FilledButton(
+                      onPressed: onRetry,
+                      child: Text(retryLabel),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/features/evaluation/presentation/communication_panel.dart
+++ b/frontend/lib/features/evaluation/presentation/communication_panel.dart
@@ -381,36 +381,44 @@ class _ScoreHero extends StatelessWidget {
         child: Row(
           children: [
             SizedBox(
-              width: 88,
-              height: 88,
+              width: 104,
+              height: 104,
               child: Stack(
                 alignment: Alignment.center,
+                clipBehavior: Clip.none,
                 children: [
-                  CircularProgressIndicator(
-                    value: progress,
-                    strokeWidth: 8,
-                    backgroundColor: AppColors.surfaceMuted,
-                    color: _ringColor,
+                  SizedBox(
+                    width: 104,
+                    height: 104,
+                    child: CircularProgressIndicator(
+                      value: progress,
+                      strokeWidth: 7,
+                      backgroundColor: AppColors.surfaceMuted,
+                      color: _ringColor,
+                    ),
                   ),
-                  Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        totalScore.toStringAsFixed(0),
-                        style: GoogleFonts.inter(
-                          fontWeight: FontWeight.w800,
-                          fontSize: 22,
-                          color: _ringColor,
+                  RichText(
+                    textAlign: TextAlign.center,
+                    text: TextSpan(
+                      children: [
+                        TextSpan(
+                          text: totalScore.toStringAsFixed(0),
+                          style: GoogleFonts.inter(
+                            fontWeight: FontWeight.w800,
+                            fontSize: 24,
+                            color: _ringColor,
+                          ),
                         ),
-                      ),
-                      Text(
-                        '/ 100',
-                        style: GoogleFonts.inter(
-                          fontSize: 11,
-                          color: AppColors.secondaryText,
+                        TextSpan(
+                          text: ' /100',
+                          style: GoogleFonts.inter(
+                            fontWeight: FontWeight.w500,
+                            fontSize: 13,
+                            color: AppColors.secondaryText,
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ],
               ),

--- a/frontend/lib/features/evaluation/presentation/communication_panel.dart
+++ b/frontend/lib/features/evaluation/presentation/communication_panel.dart
@@ -397,20 +397,24 @@ class _ScoreHero extends StatelessWidget {
                       color: _ringColor,
                     ),
                   ),
-                  RichText(
-                    textAlign: TextAlign.center,
-                    text: TextSpan(
+                  FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.baseline,
+                      textBaseline: TextBaseline.alphabetic,
                       children: [
-                        TextSpan(
-                          text: totalScore.toStringAsFixed(0),
+                        Text(
+                          totalScore.toStringAsFixed(0),
+                          key: const Key('communication_total_score'),
                           style: GoogleFonts.inter(
                             fontWeight: FontWeight.w800,
                             fontSize: 24,
                             color: _ringColor,
                           ),
                         ),
-                        TextSpan(
-                          text: ' /100',
+                        Text(
+                          ' /100',
                           style: GoogleFonts.inter(
                             fontWeight: FontWeight.w500,
                             fontSize: 13,

--- a/frontend/lib/features/evaluation/presentation/debrief_screen.dart
+++ b/frontend/lib/features/evaluation/presentation/debrief_screen.dart
@@ -3,7 +3,9 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
 import 'package:frontend/common/widgets/structured_conclusions_summary.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
+import 'package:frontend/features/evaluation/presentation/communication_panel.dart';
 import 'package:frontend/network/openapi.dart' as generated;
 import 'package:google_fonts/google_fonts.dart';
 
@@ -14,11 +16,13 @@ class DebriefScreen extends StatefulWidget {
     required this.caseItem,
     required this.sessionId,
     required this.evaluationRepository,
+    required this.communicationRepository,
   });
 
   final generated.CaseResponse caseItem;
   final String sessionId;
   final EvaluationRepositoryContract evaluationRepository;
+  final CommunicationRepositoryContract communicationRepository;
 
   @override
   State<DebriefScreen> createState() => _DebriefScreenState();
@@ -26,7 +30,9 @@ class DebriefScreen extends StatefulWidget {
 
 enum _LoadState { loading, success, forbidden, notFound, conflict, unknown }
 
-class _DebriefScreenState extends State<DebriefScreen> {
+class _DebriefScreenState extends State<DebriefScreen>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
   _LoadState _state = _LoadState.loading;
   generated.DebriefResponse? _debrief;
   String? _errorDetail;
@@ -34,7 +40,14 @@ class _DebriefScreenState extends State<DebriefScreen> {
   @override
   void initState() {
     super.initState();
+    _tabController = TabController(length: 2, vsync: this);
     _load();
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
   }
 
   Future<void> _load() async {
@@ -111,13 +124,36 @@ class _DebriefScreenState extends State<DebriefScreen> {
           'Evaluation',
           style: GoogleFonts.inter(fontWeight: FontWeight.w700, fontSize: 18),
         ),
+        bottom: _state == _LoadState.success
+            ? TabBar(
+                controller: _tabController,
+                labelStyle: GoogleFonts.inter(fontWeight: FontWeight.w600),
+                unselectedLabelStyle: GoogleFonts.inter(),
+                indicatorColor: AppColors.primaryBlue,
+                labelColor: AppColors.primaryBlue,
+                unselectedLabelColor: AppColors.secondaryText,
+                tabs: const [
+                  Tab(text: 'Clinical'),
+                  Tab(text: 'Communication'),
+                ],
+              )
+            : null,
       ),
       body: switch (_state) {
         _LoadState.loading => _LoadingBody(),
-        _LoadState.success => _SuccessBody(
-            caseItem: widget.caseItem,
-            sessionId: widget.sessionId,
-            debrief: _debrief!,
+        _LoadState.success => TabBarView(
+            controller: _tabController,
+            children: [
+              _SuccessBody(
+                caseItem: widget.caseItem,
+                sessionId: widget.sessionId,
+                debrief: _debrief!,
+              ),
+              CommunicationPanel(
+                sessionId: widget.sessionId,
+                communicationRepository: widget.communicationRepository,
+              ),
+            ],
           ),
         _LoadState.forbidden => _ErrorPanel(
             title: 'Access denied',

--- a/frontend/lib/features/sessions/presentation/duplicate_start_dialog.dart
+++ b/frontend/lib/features/sessions/presentation/duplicate_start_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
 import 'package:frontend/domains/sessions/session_start_conflict.dart';
@@ -16,6 +17,7 @@ Future<void> showDuplicateStartDialog({
   required SessionStartConflict conflict,
   required SessionRepositoryContract sessionRepository,
   required EvaluationRepositoryContract evaluationRepository,
+  required CommunicationRepositoryContract communicationRepository,
 }) async {
   await showDialog<void>(
     context: context,
@@ -24,6 +26,7 @@ Future<void> showDuplicateStartDialog({
       conflict: conflict,
       sessionRepository: sessionRepository,
       evaluationRepository: evaluationRepository,
+      communicationRepository: communicationRepository,
     ),
   );
 }
@@ -34,12 +37,14 @@ class _DuplicateStartDialog extends StatefulWidget {
     required this.conflict,
     required this.sessionRepository,
     required this.evaluationRepository,
+    required this.communicationRepository,
   });
 
   final generated.CaseResponse caseItem;
   final SessionStartConflict conflict;
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
+  final CommunicationRepositoryContract communicationRepository;
 
   @override
   State<_DuplicateStartDialog> createState() => _DuplicateStartDialogState();
@@ -62,6 +67,7 @@ class _DuplicateStartDialogState extends State<_DuplicateStartDialog> {
       sessionId: widget.conflict.existingSessionId,
       sessionRepository: widget.sessionRepository,
       evaluationRepository: widget.evaluationRepository,
+      communicationRepository: widget.communicationRepository,
     );
   }
 
@@ -84,6 +90,7 @@ class _DuplicateStartDialogState extends State<_DuplicateStartDialog> {
             sessionId: res.sessionId,
             sessionRepository: widget.sessionRepository,
             evaluationRepository: widget.evaluationRepository,
+            communicationRepository: widget.communicationRepository,
           ),
         ),
       );

--- a/frontend/lib/features/sessions/presentation/resume_session_flow.dart
+++ b/frontend/lib/features/sessions/presentation/resume_session_flow.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_hydration.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
@@ -12,6 +13,7 @@ Future<void> resumeSessionAndNavigate({
   required String sessionId,
   required SessionRepositoryContract sessionRepository,
   required EvaluationRepositoryContract evaluationRepository,
+  required CommunicationRepositoryContract communicationRepository,
 }) async {
   if (!context.mounted) return;
   showDialog<void>(
@@ -35,6 +37,7 @@ Future<void> resumeSessionAndNavigate({
           sessionId: sessionId,
           sessionRepository: sessionRepository,
           evaluationRepository: evaluationRepository,
+          communicationRepository: communicationRepository,
           initialHydration: hydration,
         ),
       ),

--- a/frontend/lib/features/sessions/presentation/unfinished_sessions_sheet.dart
+++ b/frontend/lib/features/sessions/presentation/unfinished_sessions_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
 import 'package:frontend/features/sessions/presentation/resume_session_flow.dart';
@@ -14,6 +15,7 @@ Future<void> showUnfinishedSessionsSheet({
   required BuildContext context,
   required SessionRepositoryContract sessionRepository,
   required EvaluationRepositoryContract evaluationRepository,
+  required CommunicationRepositoryContract communicationRepository,
 }) async {
   final maxHeight = MediaQuery.sizeOf(context).height * 0.62;
   await showModalBottomSheet<void>(
@@ -25,6 +27,7 @@ Future<void> showUnfinishedSessionsSheet({
     builder: (ctx) => _UnfinishedSessionsBody(
       sessionRepository: sessionRepository,
       evaluationRepository: evaluationRepository,
+      communicationRepository: communicationRepository,
     ),
   );
 }
@@ -33,10 +36,12 @@ class _UnfinishedSessionsBody extends StatefulWidget {
   const _UnfinishedSessionsBody({
     required this.sessionRepository,
     required this.evaluationRepository,
+    required this.communicationRepository,
   });
 
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
+  final CommunicationRepositoryContract communicationRepository;
 
   @override
   State<_UnfinishedSessionsBody> createState() =>
@@ -104,6 +109,7 @@ class _UnfinishedSessionsBodyState extends State<_UnfinishedSessionsBody> {
       sessionId: item.sessionId,
       sessionRepository: widget.sessionRepository,
       evaluationRepository: widget.evaluationRepository,
+      communicationRepository: widget.communicationRepository,
     );
     if (mounted) {
       setState(() => _busySessionIds.remove(item.sessionId));

--- a/frontend/lib/network/openapi.dart
+++ b/frontend/lib/network/openapi.dart
@@ -13,6 +13,7 @@ export 'package:frontend/network/src/model/date.dart';
 export 'package:frontend/network/src/api/admin_api.dart';
 export 'package:frontend/network/src/api/auth_api.dart';
 export 'package:frontend/network/src/api/cases_api.dart';
+export 'package:frontend/network/src/api/communication_evaluation_api.dart';
 export 'package:frontend/network/src/api/evaluation_api.dart';
 export 'package:frontend/network/src/api/sessions_api.dart';
 
@@ -26,6 +27,8 @@ export 'package:frontend/network/src/model/case_response.dart';
 export 'package:frontend/network/src/model/chat_message.dart';
 export 'package:frontend/network/src/model/chat_request.dart';
 export 'package:frontend/network/src/model/chat_response.dart';
+export 'package:frontend/network/src/model/communication_criterion_response.dart';
+export 'package:frontend/network/src/model/communication_evaluation_response.dart';
 export 'package:frontend/network/src/model/conclusions_request.dart';
 export 'package:frontend/network/src/model/conclusions_response.dart';
 export 'package:frontend/network/src/model/create_case_request.dart';

--- a/frontend/lib/network/src/api.dart
+++ b/frontend/lib/network/src/api.dart
@@ -12,6 +12,7 @@ import 'package:frontend/network/src/auth/oauth.dart';
 import 'package:frontend/network/src/api/admin_api.dart';
 import 'package:frontend/network/src/api/auth_api.dart';
 import 'package:frontend/network/src/api/cases_api.dart';
+import 'package:frontend/network/src/api/communication_evaluation_api.dart';
 import 'package:frontend/network/src/api/evaluation_api.dart';
 import 'package:frontend/network/src/api/sessions_api.dart';
 
@@ -151,6 +152,12 @@ class Openapi {
   /// by doing that all interceptors will not be executed
   CasesApi getCasesApi() {
     return CasesApi(dio, serializers);
+  }
+
+  /// Get CommunicationEvaluationApi instance, base route and serializer can be overridden by a given but be careful,
+  /// by doing that all interceptors will not be executed
+  CommunicationEvaluationApi getCommunicationEvaluationApi() {
+    return CommunicationEvaluationApi(dio, serializers);
   }
 
   /// Get EvaluationApi instance, base route and serializer can be overridden by a given but be careful,

--- a/frontend/lib/network/src/api/communication_evaluation_api.dart
+++ b/frontend/lib/network/src/api/communication_evaluation_api.dart
@@ -1,0 +1,191 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+import 'dart:async';
+
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'package:dio/dio.dart';
+
+import 'package:frontend/network/src/api_util.dart';
+import 'package:frontend/network/src/model/communication_evaluation_response.dart';
+import 'package:frontend/network/src/model/http_validation_error.dart';
+
+class CommunicationEvaluationApi {
+  final Dio _dio;
+
+  final Serializers _serializers;
+
+  const CommunicationEvaluationApi(this._dio, this._serializers);
+
+  /// Get Communication Evaluation
+  ///
+  ///
+  /// Parameters:
+  /// * [sessionId]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [CommunicationEvaluationResponse] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<CommunicationEvaluationResponse>>
+      getCommunicationEvaluationSessionsSessionIdCommunicationEvaluationGet({
+    required String sessionId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/sessions/{session_id}/communication-evaluation'.replaceAll(
+        '{' r'session_id' '}',
+        encodeQueryParameter(_serializers, sessionId, const FullType(String))
+            .toString());
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2PasswordBearer',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    CommunicationEvaluationResponse? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null
+          ? null
+          : _serializers.deserialize(
+              rawResponse,
+              specifiedType: const FullType(CommunicationEvaluationResponse),
+            ) as CommunicationEvaluationResponse;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<CommunicationEvaluationResponse>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// Trigger Communication Evaluation
+  ///
+  ///
+  /// Parameters:
+  /// * [sessionId]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [CommunicationEvaluationResponse] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<CommunicationEvaluationResponse>>
+      triggerCommunicationEvaluationSessionsSessionIdCommunicationEvaluationPost({
+    required String sessionId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/sessions/{session_id}/communication-evaluation'.replaceAll(
+        '{' r'session_id' '}',
+        encodeQueryParameter(_serializers, sessionId, const FullType(String))
+            .toString());
+    final _options = Options(
+      method: r'POST',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2PasswordBearer',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    CommunicationEvaluationResponse? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null
+          ? null
+          : _serializers.deserialize(
+              rawResponse,
+              specifiedType: const FullType(CommunicationEvaluationResponse),
+            ) as CommunicationEvaluationResponse;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<CommunicationEvaluationResponse>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+}

--- a/frontend/lib/network/src/api/sessions_api.dart
+++ b/frontend/lib/network/src/api/sessions_api.dart
@@ -14,6 +14,7 @@ import 'package:frontend/network/src/model/active_session_item.dart';
 import 'package:frontend/network/src/model/available_tests_response.dart';
 import 'package:frontend/network/src/model/chat_request.dart';
 import 'package:frontend/network/src/model/chat_response.dart';
+import 'package:frontend/network/src/model/communication_evaluation_response.dart';
 import 'package:frontend/network/src/model/conclusions_request.dart';
 import 'package:frontend/network/src/model/conclusions_response.dart';
 import 'package:frontend/network/src/model/debrief_response.dart';
@@ -381,6 +382,91 @@ class SessionsApi {
     }
 
     return Response<ConclusionsResponse>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// Get Communication Evaluation
+  ///
+  ///
+  /// Parameters:
+  /// * [sessionId]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [CommunicationEvaluationResponse] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<CommunicationEvaluationResponse>>
+      getCommunicationEvaluationSessionsSessionIdCommunicationEvaluationGet({
+    required String sessionId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/sessions/{session_id}/communication-evaluation'.replaceAll(
+        '{' r'session_id' '}',
+        encodeQueryParameter(_serializers, sessionId, const FullType(String))
+            .toString());
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2PasswordBearer',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    CommunicationEvaluationResponse? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null
+          ? null
+          : _serializers.deserialize(
+              rawResponse,
+              specifiedType: const FullType(CommunicationEvaluationResponse),
+            ) as CommunicationEvaluationResponse;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<CommunicationEvaluationResponse>(
       data: _responseData,
       headers: _response.headers,
       isRedirect: _response.isRedirect,
@@ -942,6 +1028,91 @@ class SessionsApi {
     }
 
     return Response<SessionResponse>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// Trigger Communication Evaluation
+  ///
+  ///
+  /// Parameters:
+  /// * [sessionId]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [CommunicationEvaluationResponse] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<CommunicationEvaluationResponse>>
+      triggerCommunicationEvaluationSessionsSessionIdCommunicationEvaluationPost({
+    required String sessionId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/sessions/{session_id}/communication-evaluation'.replaceAll(
+        '{' r'session_id' '}',
+        encodeQueryParameter(_serializers, sessionId, const FullType(String))
+            .toString());
+    final _options = Options(
+      method: r'POST',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2PasswordBearer',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    CommunicationEvaluationResponse? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null
+          ? null
+          : _serializers.deserialize(
+              rawResponse,
+              specifiedType: const FullType(CommunicationEvaluationResponse),
+            ) as CommunicationEvaluationResponse;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<CommunicationEvaluationResponse>(
       data: _responseData,
       headers: _response.headers,
       isRedirect: _response.isRedirect,

--- a/frontend/lib/network/src/model/communication_criterion_response.dart
+++ b/frontend/lib/network/src/model/communication_criterion_response.dart
@@ -1,0 +1,165 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+// ignore_for_file: unused_element
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'communication_criterion_response.g.dart';
+
+/// CommunicationCriterionResponse
+///
+/// Properties:
+/// * [criterion]
+/// * [score]
+/// * [rationale]
+/// * [quote]
+@BuiltValue()
+abstract class CommunicationCriterionResponse
+    implements
+        Built<CommunicationCriterionResponse,
+            CommunicationCriterionResponseBuilder> {
+  @BuiltValueField(wireName: r'criterion')
+  String get criterion;
+
+  @BuiltValueField(wireName: r'score')
+  int get score;
+
+  @BuiltValueField(wireName: r'rationale')
+  String get rationale;
+
+  @BuiltValueField(wireName: r'quote')
+  String get quote;
+
+  CommunicationCriterionResponse._();
+
+  factory CommunicationCriterionResponse(
+          [void updates(CommunicationCriterionResponseBuilder b)]) =
+      _$CommunicationCriterionResponse;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CommunicationCriterionResponseBuilder b) => b;
+
+  @BuiltValueSerializer(custom: true)
+  static Serializer<CommunicationCriterionResponse> get serializer =>
+      _$CommunicationCriterionResponseSerializer();
+}
+
+class _$CommunicationCriterionResponseSerializer
+    implements PrimitiveSerializer<CommunicationCriterionResponse> {
+  @override
+  final Iterable<Type> types = const [
+    CommunicationCriterionResponse,
+    _$CommunicationCriterionResponse
+  ];
+
+  @override
+  final String wireName = r'CommunicationCriterionResponse';
+
+  Iterable<Object?> _serializeProperties(
+    Serializers serializers,
+    CommunicationCriterionResponse object, {
+    FullType specifiedType = FullType.unspecified,
+  }) sync* {
+    yield r'criterion';
+    yield serializers.serialize(
+      object.criterion,
+      specifiedType: const FullType(String),
+    );
+    yield r'score';
+    yield serializers.serialize(
+      object.score,
+      specifiedType: const FullType(int),
+    );
+    yield r'rationale';
+    yield serializers.serialize(
+      object.rationale,
+      specifiedType: const FullType(String),
+    );
+    yield r'quote';
+    yield serializers.serialize(
+      object.quote,
+      specifiedType: const FullType(String),
+    );
+  }
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    CommunicationCriterionResponse object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return _serializeProperties(serializers, object,
+            specifiedType: specifiedType)
+        .toList();
+  }
+
+  void _deserializeProperties(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+    required List<Object?> serializedList,
+    required CommunicationCriterionResponseBuilder result,
+    required List<Object?> unhandled,
+  }) {
+    for (var i = 0; i < serializedList.length; i += 2) {
+      final key = serializedList[i] as String;
+      final value = serializedList[i + 1];
+      switch (key) {
+        case r'criterion':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.criterion = valueDes;
+          break;
+        case r'score':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int;
+          result.score = valueDes;
+          break;
+        case r'rationale':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.rationale = valueDes;
+          break;
+        case r'quote':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.quote = valueDes;
+          break;
+        default:
+          unhandled.add(key);
+          unhandled.add(value);
+          break;
+      }
+    }
+  }
+
+  @override
+  CommunicationCriterionResponse deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CommunicationCriterionResponseBuilder();
+    final serializedList = (serialized as Iterable<Object?>).toList();
+    final unhandled = <Object?>[];
+    _deserializeProperties(
+      serializers,
+      serialized,
+      specifiedType: specifiedType,
+      serializedList: serializedList,
+      unhandled: unhandled,
+      result: result,
+    );
+    return result.build();
+  }
+}

--- a/frontend/lib/network/src/model/communication_criterion_response.g.dart
+++ b/frontend/lib/network/src/model/communication_criterion_response.g.dart
@@ -1,0 +1,138 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'communication_criterion_response.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$CommunicationCriterionResponse extends CommunicationCriterionResponse {
+  @override
+  final String criterion;
+  @override
+  final int score;
+  @override
+  final String rationale;
+  @override
+  final String quote;
+
+  factory _$CommunicationCriterionResponse(
+          [void Function(CommunicationCriterionResponseBuilder)? updates]) =>
+      (CommunicationCriterionResponseBuilder()..update(updates))._build();
+
+  _$CommunicationCriterionResponse._(
+      {required this.criterion,
+      required this.score,
+      required this.rationale,
+      required this.quote})
+      : super._();
+  @override
+  CommunicationCriterionResponse rebuild(
+          void Function(CommunicationCriterionResponseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CommunicationCriterionResponseBuilder toBuilder() =>
+      CommunicationCriterionResponseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CommunicationCriterionResponse &&
+        criterion == other.criterion &&
+        score == other.score &&
+        rationale == other.rationale &&
+        quote == other.quote;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, criterion.hashCode);
+    _$hash = $jc(_$hash, score.hashCode);
+    _$hash = $jc(_$hash, rationale.hashCode);
+    _$hash = $jc(_$hash, quote.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CommunicationCriterionResponse')
+          ..add('criterion', criterion)
+          ..add('score', score)
+          ..add('rationale', rationale)
+          ..add('quote', quote))
+        .toString();
+  }
+}
+
+class CommunicationCriterionResponseBuilder
+    implements
+        Builder<CommunicationCriterionResponse,
+            CommunicationCriterionResponseBuilder> {
+  _$CommunicationCriterionResponse? _$v;
+
+  String? _criterion;
+  String? get criterion => _$this._criterion;
+  set criterion(String? criterion) => _$this._criterion = criterion;
+
+  int? _score;
+  int? get score => _$this._score;
+  set score(int? score) => _$this._score = score;
+
+  String? _rationale;
+  String? get rationale => _$this._rationale;
+  set rationale(String? rationale) => _$this._rationale = rationale;
+
+  String? _quote;
+  String? get quote => _$this._quote;
+  set quote(String? quote) => _$this._quote = quote;
+
+  CommunicationCriterionResponseBuilder() {
+    CommunicationCriterionResponse._defaults(this);
+  }
+
+  CommunicationCriterionResponseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _criterion = $v.criterion;
+      _score = $v.score;
+      _rationale = $v.rationale;
+      _quote = $v.quote;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CommunicationCriterionResponse other) {
+    _$v = other as _$CommunicationCriterionResponse;
+  }
+
+  @override
+  void update(void Function(CommunicationCriterionResponseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CommunicationCriterionResponse build() => _build();
+
+  _$CommunicationCriterionResponse _build() {
+    final _$result = _$v ??
+        _$CommunicationCriterionResponse._(
+          criterion: BuiltValueNullFieldError.checkNotNull(
+              criterion, r'CommunicationCriterionResponse', 'criterion'),
+          score: BuiltValueNullFieldError.checkNotNull(
+              score, r'CommunicationCriterionResponse', 'score'),
+          rationale: BuiltValueNullFieldError.checkNotNull(
+              rationale, r'CommunicationCriterionResponse', 'rationale'),
+          quote: BuiltValueNullFieldError.checkNotNull(
+              quote, r'CommunicationCriterionResponse', 'quote'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/frontend/lib/network/src/model/communication_evaluation_response.dart
+++ b/frontend/lib/network/src/model/communication_evaluation_response.dart
@@ -1,0 +1,201 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+// ignore_for_file: unused_element
+import 'package:built_collection/built_collection.dart';
+import 'package:frontend/network/src/model/communication_criterion_response.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'communication_evaluation_response.g.dart';
+
+/// CommunicationEvaluationResponse
+///
+/// Properties:
+/// * [sessionId]
+/// * [model]
+/// * [promptVersion]
+/// * [totalScore]
+/// * [createdAt]
+/// * [criteria]
+@BuiltValue()
+abstract class CommunicationEvaluationResponse
+    implements
+        Built<CommunicationEvaluationResponse,
+            CommunicationEvaluationResponseBuilder> {
+  @BuiltValueField(wireName: r'session_id')
+  String get sessionId;
+
+  @BuiltValueField(wireName: r'model')
+  String get model;
+
+  @BuiltValueField(wireName: r'prompt_version')
+  String get promptVersion;
+
+  @BuiltValueField(wireName: r'total_score')
+  num get totalScore;
+
+  @BuiltValueField(wireName: r'created_at')
+  DateTime get createdAt;
+
+  @BuiltValueField(wireName: r'criteria')
+  BuiltList<CommunicationCriterionResponse> get criteria;
+
+  CommunicationEvaluationResponse._();
+
+  factory CommunicationEvaluationResponse(
+          [void updates(CommunicationEvaluationResponseBuilder b)]) =
+      _$CommunicationEvaluationResponse;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CommunicationEvaluationResponseBuilder b) => b;
+
+  @BuiltValueSerializer(custom: true)
+  static Serializer<CommunicationEvaluationResponse> get serializer =>
+      _$CommunicationEvaluationResponseSerializer();
+}
+
+class _$CommunicationEvaluationResponseSerializer
+    implements PrimitiveSerializer<CommunicationEvaluationResponse> {
+  @override
+  final Iterable<Type> types = const [
+    CommunicationEvaluationResponse,
+    _$CommunicationEvaluationResponse
+  ];
+
+  @override
+  final String wireName = r'CommunicationEvaluationResponse';
+
+  Iterable<Object?> _serializeProperties(
+    Serializers serializers,
+    CommunicationEvaluationResponse object, {
+    FullType specifiedType = FullType.unspecified,
+  }) sync* {
+    yield r'session_id';
+    yield serializers.serialize(
+      object.sessionId,
+      specifiedType: const FullType(String),
+    );
+    yield r'model';
+    yield serializers.serialize(
+      object.model,
+      specifiedType: const FullType(String),
+    );
+    yield r'prompt_version';
+    yield serializers.serialize(
+      object.promptVersion,
+      specifiedType: const FullType(String),
+    );
+    yield r'total_score';
+    yield serializers.serialize(
+      object.totalScore,
+      specifiedType: const FullType(num),
+    );
+    yield r'created_at';
+    yield serializers.serialize(
+      object.createdAt,
+      specifiedType: const FullType(DateTime),
+    );
+    yield r'criteria';
+    yield serializers.serialize(
+      object.criteria,
+      specifiedType:
+          const FullType(BuiltList, [FullType(CommunicationCriterionResponse)]),
+    );
+  }
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    CommunicationEvaluationResponse object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return _serializeProperties(serializers, object,
+            specifiedType: specifiedType)
+        .toList();
+  }
+
+  void _deserializeProperties(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+    required List<Object?> serializedList,
+    required CommunicationEvaluationResponseBuilder result,
+    required List<Object?> unhandled,
+  }) {
+    for (var i = 0; i < serializedList.length; i += 2) {
+      final key = serializedList[i] as String;
+      final value = serializedList[i + 1];
+      switch (key) {
+        case r'session_id':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.sessionId = valueDes;
+          break;
+        case r'model':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.model = valueDes;
+          break;
+        case r'prompt_version':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.promptVersion = valueDes;
+          break;
+        case r'total_score':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(num),
+          ) as num;
+          result.totalScore = valueDes;
+          break;
+        case r'created_at':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(DateTime),
+          ) as DateTime;
+          result.createdAt = valueDes;
+          break;
+        case r'criteria':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(
+                BuiltList, [FullType(CommunicationCriterionResponse)]),
+          ) as BuiltList<CommunicationCriterionResponse>;
+          result.criteria.replace(valueDes);
+          break;
+        default:
+          unhandled.add(key);
+          unhandled.add(value);
+          break;
+      }
+    }
+  }
+
+  @override
+  CommunicationEvaluationResponse deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CommunicationEvaluationResponseBuilder();
+    final serializedList = (serialized as Iterable<Object?>).toList();
+    final unhandled = <Object?>[];
+    _deserializeProperties(
+      serializers,
+      serialized,
+      specifiedType: specifiedType,
+      serializedList: serializedList,
+      unhandled: unhandled,
+      result: result,
+    );
+    return result.build();
+  }
+}

--- a/frontend/lib/network/src/model/communication_evaluation_response.g.dart
+++ b/frontend/lib/network/src/model/communication_evaluation_response.g.dart
@@ -1,0 +1,180 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'communication_evaluation_response.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$CommunicationEvaluationResponse
+    extends CommunicationEvaluationResponse {
+  @override
+  final String sessionId;
+  @override
+  final String model;
+  @override
+  final String promptVersion;
+  @override
+  final num totalScore;
+  @override
+  final DateTime createdAt;
+  @override
+  final BuiltList<CommunicationCriterionResponse> criteria;
+
+  factory _$CommunicationEvaluationResponse(
+          [void Function(CommunicationEvaluationResponseBuilder)? updates]) =>
+      (CommunicationEvaluationResponseBuilder()..update(updates))._build();
+
+  _$CommunicationEvaluationResponse._(
+      {required this.sessionId,
+      required this.model,
+      required this.promptVersion,
+      required this.totalScore,
+      required this.createdAt,
+      required this.criteria})
+      : super._();
+  @override
+  CommunicationEvaluationResponse rebuild(
+          void Function(CommunicationEvaluationResponseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CommunicationEvaluationResponseBuilder toBuilder() =>
+      CommunicationEvaluationResponseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CommunicationEvaluationResponse &&
+        sessionId == other.sessionId &&
+        model == other.model &&
+        promptVersion == other.promptVersion &&
+        totalScore == other.totalScore &&
+        createdAt == other.createdAt &&
+        criteria == other.criteria;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, sessionId.hashCode);
+    _$hash = $jc(_$hash, model.hashCode);
+    _$hash = $jc(_$hash, promptVersion.hashCode);
+    _$hash = $jc(_$hash, totalScore.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, criteria.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CommunicationEvaluationResponse')
+          ..add('sessionId', sessionId)
+          ..add('model', model)
+          ..add('promptVersion', promptVersion)
+          ..add('totalScore', totalScore)
+          ..add('createdAt', createdAt)
+          ..add('criteria', criteria))
+        .toString();
+  }
+}
+
+class CommunicationEvaluationResponseBuilder
+    implements
+        Builder<CommunicationEvaluationResponse,
+            CommunicationEvaluationResponseBuilder> {
+  _$CommunicationEvaluationResponse? _$v;
+
+  String? _sessionId;
+  String? get sessionId => _$this._sessionId;
+  set sessionId(String? sessionId) => _$this._sessionId = sessionId;
+
+  String? _model;
+  String? get model => _$this._model;
+  set model(String? model) => _$this._model = model;
+
+  String? _promptVersion;
+  String? get promptVersion => _$this._promptVersion;
+  set promptVersion(String? promptVersion) =>
+      _$this._promptVersion = promptVersion;
+
+  num? _totalScore;
+  num? get totalScore => _$this._totalScore;
+  set totalScore(num? totalScore) => _$this._totalScore = totalScore;
+
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
+
+  ListBuilder<CommunicationCriterionResponse>? _criteria;
+  ListBuilder<CommunicationCriterionResponse> get criteria =>
+      _$this._criteria ??= ListBuilder<CommunicationCriterionResponse>();
+  set criteria(ListBuilder<CommunicationCriterionResponse>? criteria) =>
+      _$this._criteria = criteria;
+
+  CommunicationEvaluationResponseBuilder() {
+    CommunicationEvaluationResponse._defaults(this);
+  }
+
+  CommunicationEvaluationResponseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _sessionId = $v.sessionId;
+      _model = $v.model;
+      _promptVersion = $v.promptVersion;
+      _totalScore = $v.totalScore;
+      _createdAt = $v.createdAt;
+      _criteria = $v.criteria.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CommunicationEvaluationResponse other) {
+    _$v = other as _$CommunicationEvaluationResponse;
+  }
+
+  @override
+  void update(void Function(CommunicationEvaluationResponseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CommunicationEvaluationResponse build() => _build();
+
+  _$CommunicationEvaluationResponse _build() {
+    _$CommunicationEvaluationResponse _$result;
+    try {
+      _$result = _$v ??
+          _$CommunicationEvaluationResponse._(
+            sessionId: BuiltValueNullFieldError.checkNotNull(
+                sessionId, r'CommunicationEvaluationResponse', 'sessionId'),
+            model: BuiltValueNullFieldError.checkNotNull(
+                model, r'CommunicationEvaluationResponse', 'model'),
+            promptVersion: BuiltValueNullFieldError.checkNotNull(promptVersion,
+                r'CommunicationEvaluationResponse', 'promptVersion'),
+            totalScore: BuiltValueNullFieldError.checkNotNull(
+                totalScore, r'CommunicationEvaluationResponse', 'totalScore'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(
+                createdAt, r'CommunicationEvaluationResponse', 'createdAt'),
+            criteria: criteria.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'criteria';
+        criteria.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'CommunicationEvaluationResponse', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/frontend/lib/network/src/serializers.dart
+++ b/frontend/lib/network/src/serializers.dart
@@ -24,6 +24,8 @@ import 'package:frontend/network/src/model/case_response.dart';
 import 'package:frontend/network/src/model/chat_message.dart';
 import 'package:frontend/network/src/model/chat_request.dart';
 import 'package:frontend/network/src/model/chat_response.dart';
+import 'package:frontend/network/src/model/communication_criterion_response.dart';
+import 'package:frontend/network/src/model/communication_evaluation_response.dart';
 import 'package:frontend/network/src/model/conclusions_request.dart';
 import 'package:frontend/network/src/model/conclusions_response.dart';
 import 'package:frontend/network/src/model/create_case_request.dart';
@@ -79,6 +81,8 @@ part 'serializers.g.dart';
   ChatMessage,
   ChatRequest,
   ChatResponse,
+  CommunicationCriterionResponse,
+  CommunicationEvaluationResponse,
   ConclusionsRequest,
   ConclusionsResponse,
   CreateCaseRequest,

--- a/frontend/lib/network/src/serializers.g.dart
+++ b/frontend/lib/network/src/serializers.g.dart
@@ -17,6 +17,8 @@ Serializers _$serializers = (Serializers().toBuilder()
       ..add(ChatMessage.serializer)
       ..add(ChatRequest.serializer)
       ..add(ChatResponse.serializer)
+      ..add(CommunicationCriterionResponse.serializer)
+      ..add(CommunicationEvaluationResponse.serializer)
       ..add(ConclusionsRequest.serializer)
       ..add(ConclusionsResponse.serializer)
       ..add(CreateCaseRequest.serializer)
@@ -87,6 +89,10 @@ Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(AvailableTestItem)]),
           () => ListBuilder<AvailableTestItem>())
+      ..addBuilderFactory(
+          const FullType(BuiltList,
+              const [const FullType(CommunicationCriterionResponse)]),
+          () => ListBuilder<CommunicationCriterionResponse>())
       ..addBuilderFactory(
           const FullType(
               BuiltList, const [const FullType(DifferentialDiagnosisItem)]),

--- a/frontend/openapi/openapi.json
+++ b/frontend/openapi/openapi.json
@@ -1,1 +1,3425 @@
-{"openapi":"3.1.0","info":{"title":"FastAPI","version":"0.1.0"},"paths":{"/auth/signup":{"post":{"tags":["auth"],"summary":"Signup","operationId":"signup_auth_signup_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/SignupRequest"}}},"required":true},"responses":{"201":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/UserResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/auth/login":{"post":{"tags":["auth"],"summary":"Login","operationId":"login_auth_login_post","requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"$ref":"#/components/schemas/Body_login_auth_login_post"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TokenResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/auth/refresh":{"post":{"tags":["auth"],"summary":"Refresh","operationId":"refresh_auth_refresh_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/RefreshRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TokenResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/auth/verify":{"get":{"tags":["auth"],"summary":"Verify","operationId":"verify_auth_verify_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/UserResponse"}}}}},"security":[{"OAuth2PasswordBearer":[]}]}},"/auth/reset-password/request":{"post":{"tags":["auth"],"summary":"Reset Password Request","operationId":"reset_password_request_auth_reset_password_request_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PasswordResetRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MessageResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/auth/reset-password/confirm":{"post":{"tags":["auth"],"summary":"Reset Password Confirm","operationId":"reset_password_confirm_auth_reset_password_confirm_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PasswordResetConfirm"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MessageResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/cases":{"get":{"tags":["cases"],"summary":"List Cases","operationId":"list_cases_cases_get","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"status","in":"query","required":false,"schema":{"anyOf":[{"enum":["draft","review","published"],"type":"string"},{"type":"null"}],"description":"Educators: filter by workflow status","title":"Status"},"description":"Educators: filter by workflow status"}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/CaseResponse"},"title":"Response List Cases Cases Get"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"tags":["cases"],"summary":"Create Case","operationId":"create_case_cases_post","security":[{"OAuth2PasswordBearer":[]}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CreateCaseRequest"}}}},"responses":{"201":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CaseResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/cases/{id}":{"put":{"tags":["cases"],"summary":"Update Case","operationId":"update_case_cases__id__put","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"id","in":"path","required":true,"schema":{"type":"string","title":"Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/UpdateCaseRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CaseResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["cases"],"summary":"Delete Case","operationId":"delete_case_cases__id__delete","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"id","in":"path","required":true,"schema":{"type":"string","title":"Id"}}],"responses":{"204":{"description":"Successful Response"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/{session_id}/scores":{"get":{"tags":["sessions","evaluation"],"summary":"Get Scores","operationId":"get_scores_sessions__session_id__scores_get","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ScoresResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/{session_id}/debrief":{"get":{"tags":["sessions","evaluation"],"summary":"Get Debrief","operationId":"get_debrief_sessions__session_id__debrief_get","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DebriefResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/active":{"get":{"tags":["sessions"],"summary":"List Active Sessions","operationId":"list_active_sessions_sessions_active_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/ActiveSessionItem"},"type":"array","title":"Response List Active Sessions Sessions Active Get"}}}}},"security":[{"OAuth2PasswordBearer":[]}]}},"/sessions/start":{"post":{"tags":["sessions"],"summary":"Start Session","operationId":"start_session_sessions_start_post","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"force","in":"query","required":false,"schema":{"type":"boolean","default":false,"title":"Force"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/StartSessionRequest"}}}},"responses":{"201":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SessionResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/{session_id}/state":{"get":{"tags":["sessions"],"summary":"Get Session State","operationId":"get_session_state_sessions__session_id__state_get","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}},{"name":"cursor","in":"query","required":false,"schema":{"type":"integer","minimum":0,"default":0,"title":"Cursor"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SessionStateResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/{session_id}/abandon":{"post":{"tags":["sessions"],"summary":"Abandon Session","operationId":"abandon_session_sessions__session_id__abandon_post","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ConclusionsResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/{session_id}/available-tests":{"get":{"tags":["sessions"],"summary":"Available Tests","operationId":"available_tests_sessions__session_id__available_tests_get","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AvailableTestsResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/{session_id}/order-test":{"post":{"tags":["sessions"],"summary":"Order Test Endpoint","operationId":"order_test_endpoint_sessions__session_id__order_test_post","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/OrderTestRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TestResultResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/{session_id}/chat":{"post":{"tags":["sessions"],"summary":"Chat With Patient","operationId":"chat_with_patient_sessions__session_id__chat_post","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ChatRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ChatResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/{session_id}/conclusions":{"patch":{"tags":["sessions"],"summary":"Update Conclusions","operationId":"update_conclusions_sessions__session_id__conclusions_patch","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ConclusionsRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ConclusionsResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/sessions/{session_id}/finish":{"post":{"tags":["sessions"],"summary":"Finish Session","operationId":"finish_session_sessions__session_id__finish_post","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ConclusionsResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/admin/sessions":{"get":{"tags":["admin"],"summary":"List Sessions","operationId":"list_sessions_admin_sessions_get","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"page","in":"query","required":false,"schema":{"type":"integer","minimum":1,"default":1,"title":"Page"}},{"name":"page_size","in":"query","required":false,"schema":{"type":"integer","maximum":100,"minimum":1,"default":20,"title":"Page Size"}},{"name":"student","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Student"}},{"name":"case_id","in":"query","required":false,"schema":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Case Id"}},{"name":"on_date","in":"query","required":false,"schema":{"anyOf":[{"type":"string","format":"date"},{"type":"null"}],"title":"On Date"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SessionListResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/admin/sessions/{session_id}":{"get":{"tags":["admin"],"summary":"Get Session Detail","operationId":"get_session_detail_admin_sessions__session_id__get","security":[{"OAuth2PasswordBearer":[]}],"parameters":[{"name":"session_id","in":"path","required":true,"schema":{"type":"string","title":"Session Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SessionDetailResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}}},"components":{"schemas":{"AcceptableAnswerRequest":{"properties":{"field":{"type":"string","title":"Field"},"answer":{"type":"string","title":"Answer"}},"type":"object","required":["field","answer"],"title":"AcceptableAnswerRequest"},"AcceptableAnswerResponse":{"properties":{"field":{"type":"string","title":"Field"},"answer":{"type":"string","title":"Answer"}},"type":"object","required":["field","answer"],"title":"AcceptableAnswerResponse"},"ActionLogEntry":{"properties":{"role":{"type":"string","title":"Role"},"content":{"type":"string","title":"Content"},"created_at":{"type":"string","format":"date-time","title":"Created At"}},"type":"object","required":["role","content","created_at"],"title":"ActionLogEntry"},"ActiveSessionItem":{"properties":{"session_id":{"type":"string","title":"Session Id"},"case_id":{"type":"string","title":"Case Id"},"case_title":{"type":"string","title":"Case Title"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"last_activity_at":{"type":"string","format":"date-time","title":"Last Activity At"},"progress_summary":{"$ref":"#/components/schemas/ProgressSummary"}},"type":"object","required":["session_id","case_id","case_title","created_at","last_activity_at","progress_summary"],"title":"ActiveSessionItem"},"AvailableTestItem":{"properties":{"test_name":{"type":"string","title":"Test Name"},"category":{"type":"string","title":"Category"}},"type":"object","required":["test_name","category"],"title":"AvailableTestItem"},"AvailableTestsResponse":{"properties":{"tests":{"items":{"$ref":"#/components/schemas/AvailableTestItem"},"type":"array","title":"Tests"}},"type":"object","required":["tests"],"title":"AvailableTestsResponse"},"Body_login_auth_login_post":{"properties":{"grant_type":{"anyOf":[{"type":"string","pattern":"^password$"},{"type":"null"}],"title":"Grant Type"},"username":{"type":"string","title":"Username"},"password":{"type":"string","format":"password","title":"Password"},"scope":{"type":"string","title":"Scope","default":""},"client_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Client Id"},"client_secret":{"anyOf":[{"type":"string"},{"type":"null"}],"format":"password","title":"Client Secret"}},"type":"object","required":["username","password"],"title":"Body_login_auth_login_post"},"CaseResponse":{"properties":{"id":{"type":"string","title":"Id"},"case_id":{"type":"string","title":"Case Id"},"status":{"type":"string","title":"Status"},"version":{"type":"integer","title":"Version"},"created_by":{"type":"string","title":"Created By"},"title":{"type":"string","title":"Title"},"language":{"type":"string","title":"Language"},"difficulty":{"type":"string","title":"Difficulty"},"specialty":{"type":"string","title":"Specialty"},"tags":{"items":{"type":"string"},"type":"array","title":"Tags"},"age":{"type":"integer","title":"Age"},"sex":{"type":"string","title":"Sex"},"persona":{"type":"string","title":"Persona"},"tone_presets":{"items":{"type":"string"},"type":"array","title":"Tone Presets"},"chief_complaint":{"type":"string","title":"Chief Complaint"},"history_of_present_illness":{"type":"string","title":"History Of Present Illness"},"key_history_points":{"$ref":"#/components/schemas/KeyHistoryPointsResponse"},"final_diagnosis":{"type":"string","title":"Final Diagnosis"},"differential":{"items":{"type":"string"},"type":"array","title":"Differential"},"severity_or_stage":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Severity Or Stage"},"investigations":{"$ref":"#/components/schemas/InvestigationsResponse"},"management":{"$ref":"#/components/schemas/ManagementResponse"},"scoring":{"$ref":"#/components/schemas/ScoringResponse"}},"type":"object","required":["id","case_id","status","version","created_by","title","language","difficulty","specialty","tags","age","sex","persona","tone_presets","chief_complaint","history_of_present_illness","key_history_points","final_diagnosis","differential","severity_or_stage","investigations","management","scoring"],"title":"CaseResponse"},"ChatMessage":{"properties":{"role":{"type":"string","title":"Role"},"content":{"type":"string","title":"Content"},"logged_at":{"type":"string","format":"date-time","title":"Logged At"}},"type":"object","required":["role","content","logged_at"],"title":"ChatMessage"},"ChatRequest":{"properties":{"message":{"type":"string","minLength":1,"title":"Message"}},"type":"object","required":["message"],"title":"ChatRequest"},"ChatResponse":{"properties":{"response":{"type":"string","title":"Response"},"logged_at":{"type":"string","format":"date-time","title":"Logged At"}},"type":"object","required":["response","logged_at"],"title":"ChatResponse"},"ConclusionsRequest":{"properties":{"differential_diagnoses":{"anyOf":[{"items":{"$ref":"#/components/schemas/DifferentialDiagnosisItem"},"type":"array"},{"type":"null"}],"title":"Differential Diagnoses"},"final_diagnosis":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Final Diagnosis"},"treatment_plan":{"anyOf":[{"$ref":"#/components/schemas/TreatmentPlan"},{"type":"null"}]}},"type":"object","title":"ConclusionsRequest"},"ConclusionsResponse":{"properties":{"session_id":{"type":"string","title":"Session Id"},"status":{"type":"string","title":"Status"},"conclusions":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Conclusions"}},"type":"object","required":["session_id","status","conclusions"],"title":"ConclusionsResponse"},"CreateCaseRequest":{"properties":{"case_id":{"type":"string","title":"Case Id"},"title":{"type":"string","title":"Title"},"language":{"type":"string","const":"en","title":"Language"},"difficulty":{"type":"string","enum":["easy","medium","hard"],"title":"Difficulty"},"specialty":{"type":"string","title":"Specialty"},"tags":{"items":{"type":"string"},"type":"array","title":"Tags","default":[]},"age":{"type":"integer","title":"Age"},"sex":{"type":"string","enum":["female","male","other"],"title":"Sex"},"persona":{"type":"string","title":"Persona"},"tone_presets":{"items":{"type":"string"},"type":"array","title":"Tone Presets","default":[]},"chief_complaint":{"type":"string","title":"Chief Complaint"},"history_of_present_illness":{"type":"string","title":"History Of Present Illness"},"key_history_points":{"$ref":"#/components/schemas/KeyHistoryPointsRequest"},"final_diagnosis":{"type":"string","title":"Final Diagnosis"},"differential":{"items":{"type":"string"},"type":"array","title":"Differential","default":[]},"severity_or_stage":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Severity Or Stage"},"investigations":{"$ref":"#/components/schemas/InvestigationsRequest"},"management":{"$ref":"#/components/schemas/ManagementRequest"},"scoring":{"$ref":"#/components/schemas/ScoringRequest"},"status":{"type":"string","enum":["draft","review","published"],"title":"Status","default":"draft"}},"type":"object","required":["case_id","title","language","difficulty","specialty","age","sex","persona","chief_complaint","history_of_present_illness","key_history_points","final_diagnosis","investigations","management","scoring"],"title":"CreateCaseRequest"},"DebriefResponse":{"properties":{"session_id":{"type":"string","title":"Session Id"},"case_version":{"type":"integer","title":"Case Version"},"total_score":{"type":"number","title":"Total Score"},"score_diagnosis":{"type":"number","title":"Score Diagnosis"},"score_diagnostics":{"type":"number","title":"Score Diagnostics"},"score_treatment":{"type":"number","title":"Score Treatment"},"score_safety":{"type":"number","title":"Score Safety"},"scored_at":{"type":"string","format":"date-time","title":"Scored At"},"findings":{"items":{"$ref":"#/components/schemas/EvaluationFindingResponse"},"type":"array","title":"Findings"},"reference_solution":{"additionalProperties":true,"type":"object","title":"Reference Solution"},"conclusions":{"additionalProperties":true,"type":"object","title":"Conclusions"}},"type":"object","required":["session_id","case_version","total_score","score_diagnosis","score_diagnostics","score_treatment","score_safety","scored_at","findings","reference_solution","conclusions"],"title":"DebriefResponse","examples":[{"case_version":1,"conclusions":{"final_diagnosis":"STEMI","treatment_plan":{"medications":[]}},"findings":[{"actual":"Test not ordered","category":"diagnostics","deduction_points":25.0,"expected":"Order ECG","how_to_correct":"Order ECG during the diagnostic workup.","severity":"major","type":"missing_must_order","why_matters":"Must-order tests are required to confirm or rule out key diagnoses."}],"reference_solution":{"case_id":"CASE-001","final_diagnosis":"STEMI","management":{"treatment_plan":["Activate cath lab"]},"version":1},"score_diagnosis":100.0,"score_diagnostics":75.0,"score_safety":100.0,"score_treatment":80.0,"scored_at":"2026-06-14T12:00:00Z","session_id":"550e8400-e29b-41d4-a716-446655440000","total_score":82.5}]},"DifferentialDiagnosisItem":{"properties":{"rank":{"type":"integer","minimum":1.0,"title":"Rank"},"condition":{"type":"string","title":"Condition"}},"type":"object","required":["rank","condition"],"title":"DifferentialDiagnosisItem"},"EvaluationFindingResponse":{"properties":{"category":{"type":"string","title":"Category"},"type":{"type":"string","title":"Type"},"severity":{"type":"string","title":"Severity"},"expected":{"type":"string","title":"Expected"},"actual":{"type":"string","title":"Actual"},"why_matters":{"type":"string","title":"Why Matters"},"how_to_correct":{"type":"string","title":"How To Correct"},"deduction_points":{"type":"number","title":"Deduction Points"}},"type":"object","required":["category","type","severity","expected","actual","why_matters","how_to_correct","deduction_points"],"title":"EvaluationFindingResponse"},"ExpectedTestsRequest":{"properties":{"must_order":{"items":{"type":"string"},"type":"array","title":"Must Order"},"optional":{"items":{"type":"string"},"type":"array","title":"Optional"},"should_not_order":{"items":{"type":"string"},"type":"array","title":"Should Not Order"}},"type":"object","required":["must_order","optional","should_not_order"],"title":"ExpectedTestsRequest"},"ExpectedTestsResponse":{"properties":{"must_order":{"items":{"type":"string"},"type":"array","title":"Must Order"},"optional":{"items":{"type":"string"},"type":"array","title":"Optional"},"should_not_order":{"items":{"type":"string"},"type":"array","title":"Should Not Order"}},"type":"object","required":["must_order","optional","should_not_order"],"title":"ExpectedTestsResponse"},"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"InvestigationResultRequest":{"properties":{"test_name":{"type":"string","title":"Test Name"},"result_type":{"type":"string","enum":["text_report","lab_value"],"title":"Result Type"},"value":{"type":"string","title":"Value"},"unit":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Unit"},"reference_range":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Reference Range"}},"type":"object","required":["test_name","result_type","value"],"title":"InvestigationResultRequest"},"InvestigationResultResponse":{"properties":{"test_name":{"type":"string","title":"Test Name"},"result_type":{"type":"string","title":"Result Type"},"value":{"type":"string","title":"Value"},"unit":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Unit"},"reference_range":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Reference Range"}},"type":"object","required":["test_name","result_type","value","unit","reference_range"],"title":"InvestigationResultResponse"},"InvestigationsRequest":{"properties":{"catalog_hints":{"items":{"type":"string"},"type":"array","title":"Catalog Hints","default":[]},"expected":{"$ref":"#/components/schemas/ExpectedTestsRequest"},"results":{"items":{"$ref":"#/components/schemas/InvestigationResultRequest"},"type":"array","title":"Results","default":[]}},"type":"object","required":["expected"],"title":"InvestigationsRequest"},"InvestigationsResponse":{"properties":{"catalog_hints":{"items":{"type":"string"},"type":"array","title":"Catalog Hints"},"expected":{"$ref":"#/components/schemas/ExpectedTestsResponse"},"results":{"items":{"$ref":"#/components/schemas/InvestigationResultResponse"},"type":"array","title":"Results"}},"type":"object","required":["catalog_hints","expected","results"],"title":"InvestigationsResponse"},"KeyHistoryPointsRequest":{"properties":{"must_ask":{"items":{"type":"string"},"type":"array","title":"Must Ask"},"nice_to_ask":{"items":{"type":"string"},"type":"array","title":"Nice To Ask"},"red_flags":{"items":{"type":"string"},"type":"array","title":"Red Flags"}},"type":"object","required":["must_ask","nice_to_ask","red_flags"],"title":"KeyHistoryPointsRequest"},"KeyHistoryPointsResponse":{"properties":{"must_ask":{"items":{"type":"string"},"type":"array","title":"Must Ask"},"nice_to_ask":{"items":{"type":"string"},"type":"array","title":"Nice To Ask"},"red_flags":{"items":{"type":"string"},"type":"array","title":"Red Flags"}},"type":"object","required":["must_ask","nice_to_ask","red_flags"],"title":"KeyHistoryPointsResponse"},"ManagementRequest":{"properties":{"diagnostic_plan":{"items":{"type":"string"},"type":"array","title":"Diagnostic Plan"},"treatment_plan":{"items":{"type":"string"},"type":"array","title":"Treatment Plan"},"contraindications":{"items":{"type":"string"},"type":"array","title":"Contraindications"},"follow_up":{"items":{"type":"string"},"type":"array","title":"Follow Up"}},"type":"object","required":["diagnostic_plan","treatment_plan","contraindications","follow_up"],"title":"ManagementRequest"},"ManagementResponse":{"properties":{"diagnostic_plan":{"items":{"type":"string"},"type":"array","title":"Diagnostic Plan"},"treatment_plan":{"items":{"type":"string"},"type":"array","title":"Treatment Plan"},"contraindications":{"items":{"type":"string"},"type":"array","title":"Contraindications"},"follow_up":{"items":{"type":"string"},"type":"array","title":"Follow Up"}},"type":"object","required":["diagnostic_plan","treatment_plan","contraindications","follow_up"],"title":"ManagementResponse"},"Medication":{"properties":{"name":{"type":"string","title":"Name"},"dose":{"type":"string","title":"Dose"},"route":{"type":"string","title":"Route"}},"type":"object","required":["name","dose","route"],"title":"Medication"},"MessageResponse":{"properties":{"message":{"type":"string","title":"Message"}},"type":"object","required":["message"],"title":"MessageResponse"},"OrderTestRequest":{"properties":{"test_id":{"type":"string","title":"Test Id"}},"type":"object","required":["test_id"],"title":"OrderTestRequest"},"PasswordResetConfirm":{"properties":{"token":{"type":"string","title":"Token"},"new_password":{"type":"string","title":"New Password"}},"type":"object","required":["token","new_password"],"title":"PasswordResetConfirm"},"PasswordResetRequest":{"properties":{"email":{"type":"string","format":"email","title":"Email"}},"type":"object","required":["email"],"title":"PasswordResetRequest"},"ProgressSummary":{"properties":{"turn_count":{"type":"integer","title":"Turn Count"},"has_conclusions":{"type":"boolean","title":"Has Conclusions"}},"type":"object","required":["turn_count","has_conclusions"],"title":"ProgressSummary"},"RefreshRequest":{"properties":{"refresh_token":{"type":"string","title":"Refresh Token"}},"type":"object","required":["refresh_token"],"title":"RefreshRequest"},"ScoresResponse":{"properties":{"session_id":{"type":"string","title":"Session Id"},"case_version":{"type":"integer","title":"Case Version"},"total_score":{"type":"number","title":"Total Score"},"score_diagnosis":{"type":"number","title":"Score Diagnosis"},"score_diagnostics":{"type":"number","title":"Score Diagnostics"},"score_treatment":{"type":"number","title":"Score Treatment"},"score_safety":{"type":"number","title":"Score Safety"},"scored_at":{"type":"string","format":"date-time","title":"Scored At"}},"type":"object","required":["session_id","case_version","total_score","score_diagnosis","score_diagnostics","score_treatment","score_safety","scored_at"],"title":"ScoresResponse","examples":[{"case_version":1,"score_diagnosis":100.0,"score_diagnostics":75.0,"score_safety":100.0,"score_treatment":80.0,"scored_at":"2026-06-14T12:00:00Z","session_id":"550e8400-e29b-41d4-a716-446655440000","total_score":82.5}]},"ScoringRequest":{"properties":{"weight_diagnosis":{"type":"number","title":"Weight Diagnosis"},"weight_diagnostics":{"type":"number","title":"Weight Diagnostics"},"weight_treatment":{"type":"number","title":"Weight Treatment"},"weight_safety":{"type":"number","title":"Weight Safety"},"acceptable_answers":{"items":{"$ref":"#/components/schemas/AcceptableAnswerRequest"},"type":"array","title":"Acceptable Answers","default":[]},"critical_safety_errors":{"items":{"type":"string"},"type":"array","title":"Critical Safety Errors","default":[]}},"type":"object","required":["weight_diagnosis","weight_diagnostics","weight_treatment","weight_safety"],"title":"ScoringRequest"},"ScoringResponse":{"properties":{"weight_diagnosis":{"type":"number","title":"Weight Diagnosis"},"weight_diagnostics":{"type":"number","title":"Weight Diagnostics"},"weight_treatment":{"type":"number","title":"Weight Treatment"},"weight_safety":{"type":"number","title":"Weight Safety"},"acceptable_answers":{"items":{"$ref":"#/components/schemas/AcceptableAnswerResponse"},"type":"array","title":"Acceptable Answers"},"critical_safety_errors":{"items":{"type":"string"},"type":"array","title":"Critical Safety Errors"}},"type":"object","required":["weight_diagnosis","weight_diagnostics","weight_treatment","weight_safety","acceptable_answers","critical_safety_errors"],"title":"ScoringResponse"},"SessionDetailResponse":{"properties":{"session_id":{"type":"string","title":"Session Id"},"student_username":{"type":"string","title":"Student Username"},"case_id":{"type":"string","title":"Case Id"},"case_title":{"type":"string","title":"Case Title"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"action_log":{"items":{"$ref":"#/components/schemas/ActionLogEntry"},"type":"array","title":"Action Log"}},"type":"object","required":["session_id","student_username","case_id","case_title","created_at","action_log"],"title":"SessionDetailResponse"},"SessionListResponse":{"properties":{"sessions":{"items":{"$ref":"#/components/schemas/SessionSummary"},"type":"array","title":"Sessions"},"total":{"type":"integer","title":"Total"},"page":{"type":"integer","title":"Page"},"page_size":{"type":"integer","title":"Page Size"}},"type":"object","required":["sessions","total","page","page_size"],"title":"SessionListResponse"},"SessionResponse":{"properties":{"session_id":{"type":"string","title":"Session Id"},"case_id":{"type":"string","title":"Case Id"},"status":{"type":"string","title":"Status"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"last_activity_at":{"type":"string","format":"date-time","title":"Last Activity At"}},"type":"object","required":["session_id","case_id","status","created_at","last_activity_at"],"title":"SessionResponse"},"SessionStateResponse":{"properties":{"session_id":{"type":"string","title":"Session Id"},"status":{"type":"string","title":"Status"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"last_activity_at":{"type":"string","format":"date-time","title":"Last Activity At"},"case_snapshot":{"additionalProperties":true,"type":"object","title":"Case Snapshot"},"chat_history":{"items":{"$ref":"#/components/schemas/ChatMessage"},"type":"array","title":"Chat History"},"next_cursor":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Next Cursor"},"ordered_tests":{"items":{"type":"string"},"type":"array","title":"Ordered Tests"},"conclusions":{"anyOf":[{"additionalProperties":true,"type":"object"},{"type":"null"}],"title":"Conclusions"}},"type":"object","required":["session_id","status","created_at","last_activity_at","case_snapshot","chat_history","next_cursor","ordered_tests","conclusions"],"title":"SessionStateResponse"},"SessionSummary":{"properties":{"session_id":{"type":"string","title":"Session Id"},"student_username":{"type":"string","title":"Student Username"},"case_id":{"type":"string","title":"Case Id"},"case_title":{"type":"string","title":"Case Title"},"created_at":{"type":"string","format":"date-time","title":"Created At"}},"type":"object","required":["session_id","student_username","case_id","case_title","created_at"],"title":"SessionSummary"},"SignupRequest":{"properties":{"username":{"type":"string","title":"Username"},"email":{"type":"string","format":"email","title":"Email"},"password":{"type":"string","title":"Password"}},"type":"object","required":["username","email","password"],"title":"SignupRequest"},"StartSessionRequest":{"properties":{"case_id":{"type":"string","title":"Case Id"}},"type":"object","required":["case_id"],"title":"StartSessionRequest"},"TestResultResponse":{"properties":{"test_name":{"type":"string","title":"Test Name"},"result_type":{"type":"string","title":"Result Type"},"value":{"type":"string","title":"Value"},"unit":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Unit"},"reference_range":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Reference Range"},"is_normal_default":{"type":"boolean","title":"Is Normal Default"}},"type":"object","required":["test_name","result_type","value","unit","reference_range","is_normal_default"],"title":"TestResultResponse"},"TokenResponse":{"properties":{"access_token":{"type":"string","title":"Access Token"},"refresh_token":{"type":"string","title":"Refresh Token"},"token_type":{"type":"string","title":"Token Type","default":"bearer"}},"type":"object","required":["access_token","refresh_token"],"title":"TokenResponse"},"TreatmentPlan":{"properties":{"medications":{"items":{"$ref":"#/components/schemas/Medication"},"type":"array","title":"Medications","default":[]},"non_pharmacological":{"items":{"type":"string"},"type":"array","title":"Non Pharmacological","default":[]},"referrals":{"items":{"type":"string"},"type":"array","title":"Referrals","default":[]},"follow_up":{"items":{"type":"string"},"type":"array","title":"Follow Up","default":[]}},"type":"object","title":"TreatmentPlan"},"UpdateCaseRequest":{"properties":{"title":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Title"},"language":{"anyOf":[{"type":"string","const":"en"},{"type":"null"}],"title":"Language"},"difficulty":{"anyOf":[{"type":"string","enum":["easy","medium","hard"]},{"type":"null"}],"title":"Difficulty"},"specialty":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Specialty"},"tags":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Tags"},"age":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Age"},"sex":{"anyOf":[{"type":"string","enum":["female","male","other"]},{"type":"null"}],"title":"Sex"},"persona":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Persona"},"tone_presets":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Tone Presets"},"chief_complaint":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Chief Complaint"},"history_of_present_illness":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"History Of Present Illness"},"key_history_points":{"anyOf":[{"$ref":"#/components/schemas/KeyHistoryPointsRequest"},{"type":"null"}]},"final_diagnosis":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Final Diagnosis"},"differential":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Differential"},"severity_or_stage":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Severity Or Stage"},"investigations":{"anyOf":[{"$ref":"#/components/schemas/InvestigationsRequest"},{"type":"null"}]},"management":{"anyOf":[{"$ref":"#/components/schemas/ManagementRequest"},{"type":"null"}]},"scoring":{"anyOf":[{"$ref":"#/components/schemas/ScoringRequest"},{"type":"null"}]},"status":{"anyOf":[{"type":"string","enum":["draft","review","published"]},{"type":"null"}],"title":"Status"}},"type":"object","title":"UpdateCaseRequest"},"UserResponse":{"properties":{"id":{"type":"string","title":"Id"},"username":{"type":"string","title":"Username"},"email":{"type":"string","title":"Email"},"role":{"type":"string","title":"Role"}},"type":"object","required":["id","username","email","role"],"title":"UserResponse"},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"},"input":{"title":"Input"},"ctx":{"type":"object","title":"Context"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"}},"securitySchemes":{"OAuth2PasswordBearer":{"type":"oauth2","flows":{"password":{"scopes":{},"tokenUrl":"/auth/login"}}}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/auth/signup": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Signup",
+        "operationId": "signup_auth_signup_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login",
+        "operationId": "login_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login_auth_login_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/refresh": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Refresh",
+        "operationId": "refresh_auth_refresh_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/verify": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Verify",
+        "operationId": "verify_auth_verify_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/auth/reset-password/request": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Reset Password Request",
+        "operationId": "reset_password_request_auth_reset_password_request_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordResetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/reset-password/confirm": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Reset Password Confirm",
+        "operationId": "reset_password_confirm_auth_reset_password_confirm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordResetConfirm"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cases": {
+      "get": {
+        "tags": [
+          "cases"
+        ],
+        "summary": "List Cases",
+        "operationId": "list_cases_cases_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "draft",
+                    "review",
+                    "published"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Educators: filter by workflow status",
+              "title": "Status"
+            },
+            "description": "Educators: filter by workflow status"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CaseResponse"
+                  },
+                  "title": "Response List Cases Cases Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "cases"
+        ],
+        "summary": "Create Case",
+        "operationId": "create_case_cases_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCaseRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CaseResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cases/{id}": {
+      "put": {
+        "tags": [
+          "cases"
+        ],
+        "summary": "Update Case",
+        "operationId": "update_case_cases__id__put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCaseRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CaseResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "cases"
+        ],
+        "summary": "Delete Case",
+        "operationId": "delete_case_cases__id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/scores": {
+      "get": {
+        "tags": [
+          "sessions",
+          "evaluation"
+        ],
+        "summary": "Get Scores",
+        "operationId": "get_scores_sessions__session_id__scores_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScoresResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/debrief": {
+      "get": {
+        "tags": [
+          "sessions",
+          "evaluation"
+        ],
+        "summary": "Get Debrief",
+        "operationId": "get_debrief_sessions__session_id__debrief_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebriefResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/communication-evaluation": {
+      "post": {
+        "tags": [
+          "sessions",
+          "communication-evaluation"
+        ],
+        "summary": "Trigger Communication Evaluation",
+        "operationId": "trigger_communication_evaluation_sessions__session_id__communication_evaluation_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunicationEvaluationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "sessions",
+          "communication-evaluation"
+        ],
+        "summary": "Get Communication Evaluation",
+        "operationId": "get_communication_evaluation_sessions__session_id__communication_evaluation_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunicationEvaluationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/active": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "List Active Sessions",
+        "operationId": "list_active_sessions_sessions_active_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ActiveSessionItem"
+                  },
+                  "type": "array",
+                  "title": "Response List Active Sessions Sessions Active Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/sessions/start": {
+      "post": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Start Session",
+        "operationId": "start_session_sessions_start_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Force"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/state": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Get Session State",
+        "operationId": "get_session_state_sessions__session_id__state_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionStateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/abandon": {
+      "post": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Abandon Session",
+        "operationId": "abandon_session_sessions__session_id__abandon_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConclusionsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/available-tests": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Available Tests",
+        "operationId": "available_tests_sessions__session_id__available_tests_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AvailableTestsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/order-test": {
+      "post": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Order Test Endpoint",
+        "operationId": "order_test_endpoint_sessions__session_id__order_test_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderTestRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestResultResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/chat": {
+      "post": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Chat With Patient",
+        "operationId": "chat_with_patient_sessions__session_id__chat_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/conclusions": {
+      "patch": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Update Conclusions",
+        "operationId": "update_conclusions_sessions__session_id__conclusions_patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConclusionsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConclusionsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/finish": {
+      "post": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Finish Session",
+        "operationId": "finish_session_sessions__session_id__finish_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConclusionsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/sessions": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "List Sessions",
+        "operationId": "list_sessions_admin_sessions_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Page Size"
+            }
+          },
+          {
+            "name": "student",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Student"
+            }
+          },
+          {
+            "name": "case_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Case Id"
+            }
+          },
+          {
+            "name": "on_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "On Date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/sessions/{session_id}": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get Session Detail",
+        "operationId": "get_session_detail_admin_sessions__session_id__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionDetailResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AcceptableAnswerRequest": {
+        "properties": {
+          "field": {
+            "type": "string",
+            "title": "Field"
+          },
+          "answer": {
+            "type": "string",
+            "title": "Answer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "field",
+          "answer"
+        ],
+        "title": "AcceptableAnswerRequest"
+      },
+      "AcceptableAnswerResponse": {
+        "properties": {
+          "field": {
+            "type": "string",
+            "title": "Field"
+          },
+          "answer": {
+            "type": "string",
+            "title": "Answer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "field",
+          "answer"
+        ],
+        "title": "AcceptableAnswerResponse"
+      },
+      "ActionLogEntry": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "title": "Role"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "role",
+          "content",
+          "created_at"
+        ],
+        "title": "ActionLogEntry"
+      },
+      "ActiveSessionItem": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "case_id": {
+            "type": "string",
+            "title": "Case Id"
+          },
+          "case_title": {
+            "type": "string",
+            "title": "Case Title"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "last_activity_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Activity At"
+          },
+          "progress_summary": {
+            "$ref": "#/components/schemas/ProgressSummary"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "case_id",
+          "case_title",
+          "created_at",
+          "last_activity_at",
+          "progress_summary"
+        ],
+        "title": "ActiveSessionItem"
+      },
+      "AvailableTestItem": {
+        "properties": {
+          "test_name": {
+            "type": "string",
+            "title": "Test Name"
+          },
+          "category": {
+            "type": "string",
+            "title": "Category"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_name",
+          "category"
+        ],
+        "title": "AvailableTestItem"
+      },
+      "AvailableTestsResponse": {
+        "properties": {
+          "tests": {
+            "items": {
+              "$ref": "#/components/schemas/AvailableTestItem"
+            },
+            "type": "array",
+            "title": "Tests"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tests"
+        ],
+        "title": "AvailableTestsResponse"
+      },
+      "Body_login_auth_login_post": {
+        "properties": {
+          "grant_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^password$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "title": "Password"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": ""
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "format": "password",
+            "title": "Client Secret"
+          }
+        },
+        "type": "object",
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_login_auth_login_post"
+      },
+      "CaseResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "case_id": {
+            "type": "string",
+            "title": "Case Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version"
+          },
+          "created_by": {
+            "type": "string",
+            "title": "Created By"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "language": {
+            "type": "string",
+            "title": "Language"
+          },
+          "difficulty": {
+            "type": "string",
+            "title": "Difficulty"
+          },
+          "specialty": {
+            "type": "string",
+            "title": "Specialty"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "age": {
+            "type": "integer",
+            "title": "Age"
+          },
+          "sex": {
+            "type": "string",
+            "title": "Sex"
+          },
+          "persona": {
+            "type": "string",
+            "title": "Persona"
+          },
+          "tone_presets": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tone Presets"
+          },
+          "chief_complaint": {
+            "type": "string",
+            "title": "Chief Complaint"
+          },
+          "history_of_present_illness": {
+            "type": "string",
+            "title": "History Of Present Illness"
+          },
+          "key_history_points": {
+            "$ref": "#/components/schemas/KeyHistoryPointsResponse"
+          },
+          "final_diagnosis": {
+            "type": "string",
+            "title": "Final Diagnosis"
+          },
+          "differential": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Differential"
+          },
+          "severity_or_stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity Or Stage"
+          },
+          "investigations": {
+            "$ref": "#/components/schemas/InvestigationsResponse"
+          },
+          "management": {
+            "$ref": "#/components/schemas/ManagementResponse"
+          },
+          "scoring": {
+            "$ref": "#/components/schemas/ScoringResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "case_id",
+          "status",
+          "version",
+          "created_by",
+          "title",
+          "language",
+          "difficulty",
+          "specialty",
+          "tags",
+          "age",
+          "sex",
+          "persona",
+          "tone_presets",
+          "chief_complaint",
+          "history_of_present_illness",
+          "key_history_points",
+          "final_diagnosis",
+          "differential",
+          "severity_or_stage",
+          "investigations",
+          "management",
+          "scoring"
+        ],
+        "title": "CaseResponse"
+      },
+      "ChatMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "title": "Role"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "logged_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Logged At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "role",
+          "content",
+          "logged_at"
+        ],
+        "title": "ChatMessage"
+      },
+      "ChatRequest": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "title": "ChatRequest"
+      },
+      "ChatResponse": {
+        "properties": {
+          "response": {
+            "type": "string",
+            "title": "Response"
+          },
+          "logged_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Logged At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "response",
+          "logged_at"
+        ],
+        "title": "ChatResponse"
+      },
+      "CommunicationCriterionResponse": {
+        "properties": {
+          "criterion": {
+            "type": "string",
+            "title": "Criterion"
+          },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
+          "rationale": {
+            "type": "string",
+            "title": "Rationale"
+          },
+          "quote": {
+            "type": "string",
+            "title": "Quote"
+          }
+        },
+        "type": "object",
+        "required": [
+          "criterion",
+          "score",
+          "rationale",
+          "quote"
+        ],
+        "title": "CommunicationCriterionResponse"
+      },
+      "CommunicationEvaluationResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "prompt_version": {
+            "type": "string",
+            "title": "Prompt Version"
+          },
+          "total_score": {
+            "type": "number",
+            "title": "Total Score"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "criteria": {
+            "items": {
+              "$ref": "#/components/schemas/CommunicationCriterionResponse"
+            },
+            "type": "array",
+            "title": "Criteria"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "model",
+          "prompt_version",
+          "total_score",
+          "created_at",
+          "criteria"
+        ],
+        "title": "CommunicationEvaluationResponse",
+        "examples": [
+          {
+            "created_at": "2026-06-19T12:00:00Z",
+            "criteria": [
+              {
+                "criterion": "open_ended_questions",
+                "quote": "Can you tell me more?",
+                "rationale": "Used open-ended questions.",
+                "score": 4
+              }
+            ],
+            "model": "mock",
+            "prompt_version": "v1",
+            "session_id": "550e8400-e29b-41d4-a716-446655440000",
+            "total_score": 76.0
+          }
+        ]
+      },
+      "ConclusionsRequest": {
+        "properties": {
+          "differential_diagnoses": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DifferentialDiagnosisItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Differential Diagnoses"
+          },
+          "final_diagnosis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Final Diagnosis"
+          },
+          "treatment_plan": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TreatmentPlan"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ConclusionsRequest"
+      },
+      "ConclusionsResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "conclusions": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conclusions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "status",
+          "conclusions"
+        ],
+        "title": "ConclusionsResponse"
+      },
+      "CreateCaseRequest": {
+        "properties": {
+          "case_id": {
+            "type": "string",
+            "title": "Case Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "language": {
+            "type": "string",
+            "const": "en",
+            "title": "Language"
+          },
+          "difficulty": {
+            "type": "string",
+            "enum": [
+              "easy",
+              "medium",
+              "hard"
+            ],
+            "title": "Difficulty"
+          },
+          "specialty": {
+            "type": "string",
+            "title": "Specialty"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "default": []
+          },
+          "age": {
+            "type": "integer",
+            "title": "Age"
+          },
+          "sex": {
+            "type": "string",
+            "enum": [
+              "female",
+              "male",
+              "other"
+            ],
+            "title": "Sex"
+          },
+          "persona": {
+            "type": "string",
+            "title": "Persona"
+          },
+          "tone_presets": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tone Presets",
+            "default": []
+          },
+          "chief_complaint": {
+            "type": "string",
+            "title": "Chief Complaint"
+          },
+          "history_of_present_illness": {
+            "type": "string",
+            "title": "History Of Present Illness"
+          },
+          "key_history_points": {
+            "$ref": "#/components/schemas/KeyHistoryPointsRequest"
+          },
+          "final_diagnosis": {
+            "type": "string",
+            "title": "Final Diagnosis"
+          },
+          "differential": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Differential",
+            "default": []
+          },
+          "severity_or_stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity Or Stage"
+          },
+          "investigations": {
+            "$ref": "#/components/schemas/InvestigationsRequest"
+          },
+          "management": {
+            "$ref": "#/components/schemas/ManagementRequest"
+          },
+          "scoring": {
+            "$ref": "#/components/schemas/ScoringRequest"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "review",
+              "published"
+            ],
+            "title": "Status",
+            "default": "draft"
+          }
+        },
+        "type": "object",
+        "required": [
+          "case_id",
+          "title",
+          "language",
+          "difficulty",
+          "specialty",
+          "age",
+          "sex",
+          "persona",
+          "chief_complaint",
+          "history_of_present_illness",
+          "key_history_points",
+          "final_diagnosis",
+          "investigations",
+          "management",
+          "scoring"
+        ],
+        "title": "CreateCaseRequest"
+      },
+      "DebriefResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "case_version": {
+            "type": "integer",
+            "title": "Case Version"
+          },
+          "total_score": {
+            "type": "number",
+            "title": "Total Score"
+          },
+          "score_diagnosis": {
+            "type": "number",
+            "title": "Score Diagnosis"
+          },
+          "score_diagnostics": {
+            "type": "number",
+            "title": "Score Diagnostics"
+          },
+          "score_treatment": {
+            "type": "number",
+            "title": "Score Treatment"
+          },
+          "score_safety": {
+            "type": "number",
+            "title": "Score Safety"
+          },
+          "scored_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Scored At"
+          },
+          "findings": {
+            "items": {
+              "$ref": "#/components/schemas/EvaluationFindingResponse"
+            },
+            "type": "array",
+            "title": "Findings"
+          },
+          "reference_solution": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Reference Solution"
+          },
+          "conclusions": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Conclusions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "case_version",
+          "total_score",
+          "score_diagnosis",
+          "score_diagnostics",
+          "score_treatment",
+          "score_safety",
+          "scored_at",
+          "findings",
+          "reference_solution",
+          "conclusions"
+        ],
+        "title": "DebriefResponse",
+        "examples": [
+          {
+            "case_version": 1,
+            "conclusions": {
+              "final_diagnosis": "STEMI",
+              "treatment_plan": {
+                "medications": []
+              }
+            },
+            "findings": [
+              {
+                "actual": "Test not ordered",
+                "category": "diagnostics",
+                "deduction_points": 25.0,
+                "expected": "Order ECG",
+                "how_to_correct": "Order ECG during the diagnostic workup.",
+                "severity": "major",
+                "type": "missing_must_order",
+                "why_matters": "Must-order tests are required to confirm or rule out key diagnoses."
+              }
+            ],
+            "reference_solution": {
+              "case_id": "CASE-001",
+              "final_diagnosis": "STEMI",
+              "management": {
+                "treatment_plan": [
+                  "Activate cath lab"
+                ]
+              },
+              "version": 1
+            },
+            "score_diagnosis": 100.0,
+            "score_diagnostics": 75.0,
+            "score_safety": 100.0,
+            "score_treatment": 80.0,
+            "scored_at": "2026-06-14T12:00:00Z",
+            "session_id": "550e8400-e29b-41d4-a716-446655440000",
+            "total_score": 82.5
+          }
+        ]
+      },
+      "DifferentialDiagnosisItem": {
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Rank"
+          },
+          "condition": {
+            "type": "string",
+            "title": "Condition"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rank",
+          "condition"
+        ],
+        "title": "DifferentialDiagnosisItem"
+      },
+      "EvaluationFindingResponse": {
+        "properties": {
+          "category": {
+            "type": "string",
+            "title": "Category"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "severity": {
+            "type": "string",
+            "title": "Severity"
+          },
+          "expected": {
+            "type": "string",
+            "title": "Expected"
+          },
+          "actual": {
+            "type": "string",
+            "title": "Actual"
+          },
+          "why_matters": {
+            "type": "string",
+            "title": "Why Matters"
+          },
+          "how_to_correct": {
+            "type": "string",
+            "title": "How To Correct"
+          },
+          "deduction_points": {
+            "type": "number",
+            "title": "Deduction Points"
+          }
+        },
+        "type": "object",
+        "required": [
+          "category",
+          "type",
+          "severity",
+          "expected",
+          "actual",
+          "why_matters",
+          "how_to_correct",
+          "deduction_points"
+        ],
+        "title": "EvaluationFindingResponse"
+      },
+      "ExpectedTestsRequest": {
+        "properties": {
+          "must_order": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Must Order"
+          },
+          "optional": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Optional"
+          },
+          "should_not_order": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Should Not Order"
+          }
+        },
+        "type": "object",
+        "required": [
+          "must_order",
+          "optional",
+          "should_not_order"
+        ],
+        "title": "ExpectedTestsRequest"
+      },
+      "ExpectedTestsResponse": {
+        "properties": {
+          "must_order": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Must Order"
+          },
+          "optional": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Optional"
+          },
+          "should_not_order": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Should Not Order"
+          }
+        },
+        "type": "object",
+        "required": [
+          "must_order",
+          "optional",
+          "should_not_order"
+        ],
+        "title": "ExpectedTestsResponse"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "InvestigationResultRequest": {
+        "properties": {
+          "test_name": {
+            "type": "string",
+            "title": "Test Name"
+          },
+          "result_type": {
+            "type": "string",
+            "enum": [
+              "text_report",
+              "lab_value"
+            ],
+            "title": "Result Type"
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "reference_range": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Range"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_name",
+          "result_type",
+          "value"
+        ],
+        "title": "InvestigationResultRequest"
+      },
+      "InvestigationResultResponse": {
+        "properties": {
+          "test_name": {
+            "type": "string",
+            "title": "Test Name"
+          },
+          "result_type": {
+            "type": "string",
+            "title": "Result Type"
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "reference_range": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Range"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_name",
+          "result_type",
+          "value",
+          "unit",
+          "reference_range"
+        ],
+        "title": "InvestigationResultResponse"
+      },
+      "InvestigationsRequest": {
+        "properties": {
+          "catalog_hints": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Catalog Hints",
+            "default": []
+          },
+          "expected": {
+            "$ref": "#/components/schemas/ExpectedTestsRequest"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/InvestigationResultRequest"
+            },
+            "type": "array",
+            "title": "Results",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "expected"
+        ],
+        "title": "InvestigationsRequest"
+      },
+      "InvestigationsResponse": {
+        "properties": {
+          "catalog_hints": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Catalog Hints"
+          },
+          "expected": {
+            "$ref": "#/components/schemas/ExpectedTestsResponse"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/InvestigationResultResponse"
+            },
+            "type": "array",
+            "title": "Results"
+          }
+        },
+        "type": "object",
+        "required": [
+          "catalog_hints",
+          "expected",
+          "results"
+        ],
+        "title": "InvestigationsResponse"
+      },
+      "KeyHistoryPointsRequest": {
+        "properties": {
+          "must_ask": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Must Ask"
+          },
+          "nice_to_ask": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Nice To Ask"
+          },
+          "red_flags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Red Flags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "must_ask",
+          "nice_to_ask",
+          "red_flags"
+        ],
+        "title": "KeyHistoryPointsRequest"
+      },
+      "KeyHistoryPointsResponse": {
+        "properties": {
+          "must_ask": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Must Ask"
+          },
+          "nice_to_ask": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Nice To Ask"
+          },
+          "red_flags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Red Flags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "must_ask",
+          "nice_to_ask",
+          "red_flags"
+        ],
+        "title": "KeyHistoryPointsResponse"
+      },
+      "ManagementRequest": {
+        "properties": {
+          "diagnostic_plan": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Diagnostic Plan"
+          },
+          "treatment_plan": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Treatment Plan"
+          },
+          "contraindications": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Contraindications"
+          },
+          "follow_up": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Follow Up"
+          }
+        },
+        "type": "object",
+        "required": [
+          "diagnostic_plan",
+          "treatment_plan",
+          "contraindications",
+          "follow_up"
+        ],
+        "title": "ManagementRequest"
+      },
+      "ManagementResponse": {
+        "properties": {
+          "diagnostic_plan": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Diagnostic Plan"
+          },
+          "treatment_plan": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Treatment Plan"
+          },
+          "contraindications": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Contraindications"
+          },
+          "follow_up": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Follow Up"
+          }
+        },
+        "type": "object",
+        "required": [
+          "diagnostic_plan",
+          "treatment_plan",
+          "contraindications",
+          "follow_up"
+        ],
+        "title": "ManagementResponse"
+      },
+      "Medication": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "dose": {
+            "type": "string",
+            "title": "Dose"
+          },
+          "route": {
+            "type": "string",
+            "title": "Route"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "dose",
+          "route"
+        ],
+        "title": "Medication"
+      },
+      "MessageResponse": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "title": "MessageResponse"
+      },
+      "OrderTestRequest": {
+        "properties": {
+          "test_id": {
+            "type": "string",
+            "title": "Test Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_id"
+        ],
+        "title": "OrderTestRequest"
+      },
+      "PasswordResetConfirm": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "new_password": {
+            "type": "string",
+            "title": "New Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token",
+          "new_password"
+        ],
+        "title": "PasswordResetConfirm"
+      },
+      "PasswordResetRequest": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "title": "PasswordResetRequest"
+      },
+      "ProgressSummary": {
+        "properties": {
+          "turn_count": {
+            "type": "integer",
+            "title": "Turn Count"
+          },
+          "has_conclusions": {
+            "type": "boolean",
+            "title": "Has Conclusions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "turn_count",
+          "has_conclusions"
+        ],
+        "title": "ProgressSummary"
+      },
+      "RefreshRequest": {
+        "properties": {
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "refresh_token"
+        ],
+        "title": "RefreshRequest"
+      },
+      "ScoresResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "case_version": {
+            "type": "integer",
+            "title": "Case Version"
+          },
+          "total_score": {
+            "type": "number",
+            "title": "Total Score"
+          },
+          "score_diagnosis": {
+            "type": "number",
+            "title": "Score Diagnosis"
+          },
+          "score_diagnostics": {
+            "type": "number",
+            "title": "Score Diagnostics"
+          },
+          "score_treatment": {
+            "type": "number",
+            "title": "Score Treatment"
+          },
+          "score_safety": {
+            "type": "number",
+            "title": "Score Safety"
+          },
+          "scored_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Scored At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "case_version",
+          "total_score",
+          "score_diagnosis",
+          "score_diagnostics",
+          "score_treatment",
+          "score_safety",
+          "scored_at"
+        ],
+        "title": "ScoresResponse",
+        "examples": [
+          {
+            "case_version": 1,
+            "score_diagnosis": 100.0,
+            "score_diagnostics": 75.0,
+            "score_safety": 100.0,
+            "score_treatment": 80.0,
+            "scored_at": "2026-06-14T12:00:00Z",
+            "session_id": "550e8400-e29b-41d4-a716-446655440000",
+            "total_score": 82.5
+          }
+        ]
+      },
+      "ScoringRequest": {
+        "properties": {
+          "weight_diagnosis": {
+            "type": "number",
+            "title": "Weight Diagnosis"
+          },
+          "weight_diagnostics": {
+            "type": "number",
+            "title": "Weight Diagnostics"
+          },
+          "weight_treatment": {
+            "type": "number",
+            "title": "Weight Treatment"
+          },
+          "weight_safety": {
+            "type": "number",
+            "title": "Weight Safety"
+          },
+          "acceptable_answers": {
+            "items": {
+              "$ref": "#/components/schemas/AcceptableAnswerRequest"
+            },
+            "type": "array",
+            "title": "Acceptable Answers",
+            "default": []
+          },
+          "critical_safety_errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Critical Safety Errors",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "weight_diagnosis",
+          "weight_diagnostics",
+          "weight_treatment",
+          "weight_safety"
+        ],
+        "title": "ScoringRequest"
+      },
+      "ScoringResponse": {
+        "properties": {
+          "weight_diagnosis": {
+            "type": "number",
+            "title": "Weight Diagnosis"
+          },
+          "weight_diagnostics": {
+            "type": "number",
+            "title": "Weight Diagnostics"
+          },
+          "weight_treatment": {
+            "type": "number",
+            "title": "Weight Treatment"
+          },
+          "weight_safety": {
+            "type": "number",
+            "title": "Weight Safety"
+          },
+          "acceptable_answers": {
+            "items": {
+              "$ref": "#/components/schemas/AcceptableAnswerResponse"
+            },
+            "type": "array",
+            "title": "Acceptable Answers"
+          },
+          "critical_safety_errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Critical Safety Errors"
+          }
+        },
+        "type": "object",
+        "required": [
+          "weight_diagnosis",
+          "weight_diagnostics",
+          "weight_treatment",
+          "weight_safety",
+          "acceptable_answers",
+          "critical_safety_errors"
+        ],
+        "title": "ScoringResponse"
+      },
+      "SessionDetailResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "student_username": {
+            "type": "string",
+            "title": "Student Username"
+          },
+          "case_id": {
+            "type": "string",
+            "title": "Case Id"
+          },
+          "case_title": {
+            "type": "string",
+            "title": "Case Title"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "action_log": {
+            "items": {
+              "$ref": "#/components/schemas/ActionLogEntry"
+            },
+            "type": "array",
+            "title": "Action Log"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "student_username",
+          "case_id",
+          "case_title",
+          "created_at",
+          "action_log"
+        ],
+        "title": "SessionDetailResponse"
+      },
+      "SessionListResponse": {
+        "properties": {
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/SessionSummary"
+            },
+            "type": "array",
+            "title": "Sessions"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "page_size": {
+            "type": "integer",
+            "title": "Page Size"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sessions",
+          "total",
+          "page",
+          "page_size"
+        ],
+        "title": "SessionListResponse"
+      },
+      "SessionResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "case_id": {
+            "type": "string",
+            "title": "Case Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "last_activity_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Activity At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "case_id",
+          "status",
+          "created_at",
+          "last_activity_at"
+        ],
+        "title": "SessionResponse"
+      },
+      "SessionStateResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "last_activity_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Activity At"
+          },
+          "case_snapshot": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Case Snapshot"
+          },
+          "chat_history": {
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array",
+            "title": "Chat History"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "ordered_tests": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Ordered Tests"
+          },
+          "conclusions": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conclusions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "status",
+          "created_at",
+          "last_activity_at",
+          "case_snapshot",
+          "chat_history",
+          "next_cursor",
+          "ordered_tests",
+          "conclusions"
+        ],
+        "title": "SessionStateResponse"
+      },
+      "SessionSummary": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "student_username": {
+            "type": "string",
+            "title": "Student Username"
+          },
+          "case_id": {
+            "type": "string",
+            "title": "Case Id"
+          },
+          "case_title": {
+            "type": "string",
+            "title": "Case Title"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "student_username",
+          "case_id",
+          "case_title",
+          "created_at"
+        ],
+        "title": "SessionSummary"
+      },
+      "SignupRequest": {
+        "properties": {
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "username",
+          "email",
+          "password"
+        ],
+        "title": "SignupRequest"
+      },
+      "StartSessionRequest": {
+        "properties": {
+          "case_id": {
+            "type": "string",
+            "title": "Case Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "case_id"
+        ],
+        "title": "StartSessionRequest"
+      },
+      "TestResultResponse": {
+        "properties": {
+          "test_name": {
+            "type": "string",
+            "title": "Test Name"
+          },
+          "result_type": {
+            "type": "string",
+            "title": "Result Type"
+          },
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit"
+          },
+          "reference_range": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Range"
+          },
+          "is_normal_default": {
+            "type": "boolean",
+            "title": "Is Normal Default"
+          }
+        },
+        "type": "object",
+        "required": [
+          "test_name",
+          "result_type",
+          "value",
+          "unit",
+          "reference_range",
+          "is_normal_default"
+        ],
+        "title": "TestResultResponse"
+      },
+      "TokenResponse": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type",
+            "default": "bearer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token",
+          "refresh_token"
+        ],
+        "title": "TokenResponse"
+      },
+      "TreatmentPlan": {
+        "properties": {
+          "medications": {
+            "items": {
+              "$ref": "#/components/schemas/Medication"
+            },
+            "type": "array",
+            "title": "Medications",
+            "default": []
+          },
+          "non_pharmacological": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Non Pharmacological",
+            "default": []
+          },
+          "referrals": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Referrals",
+            "default": []
+          },
+          "follow_up": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Follow Up",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "TreatmentPlan"
+      },
+      "UpdateCaseRequest": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "en"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "difficulty": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "easy",
+                  "medium",
+                  "hard"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Difficulty"
+          },
+          "specialty": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Specialty"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "age": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Age"
+          },
+          "sex": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "female",
+                  "male",
+                  "other"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sex"
+          },
+          "persona": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Persona"
+          },
+          "tone_presets": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tone Presets"
+          },
+          "chief_complaint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chief Complaint"
+          },
+          "history_of_present_illness": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "History Of Present Illness"
+          },
+          "key_history_points": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/KeyHistoryPointsRequest"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "final_diagnosis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Final Diagnosis"
+          },
+          "differential": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Differential"
+          },
+          "severity_or_stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity Or Stage"
+          },
+          "investigations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InvestigationsRequest"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "management": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ManagementRequest"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scoring": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScoringRequest"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "draft",
+                  "review",
+                  "published"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "title": "UpdateCaseRequest"
+      },
+      "UserResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "role": {
+            "type": "string",
+            "title": "Role"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "username",
+          "email",
+          "role"
+        ],
+        "title": "UserResponse"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "OAuth2PasswordBearer": {
+        "type": "oauth2",
+        "flows": {
+          "password": {
+            "scopes": {},
+            "tokenUrl": "/auth/login"
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/test/features/evaluation/communication_panel_test.dart
+++ b/frontend/test/features/evaluation/communication_panel_test.dart
@@ -31,6 +31,7 @@ void main() {
     gate.complete();
     await tester.pumpAndSettle();
     expect(find.text('76'), findsOneWidget);
+    expect(find.textContaining('/100'), findsOneWidget);
   });
 
   testWidgets('success shows all criteria with quote', (tester) async {
@@ -49,6 +50,7 @@ void main() {
 
     expect(find.text('Communication coaching'), findsOneWidget);
     expect(find.text('76'), findsOneWidget);
+    expect(find.textContaining('/100'), findsOneWidget);
     expect(find.text('Open-ended questions'), findsOneWidget);
     expect(find.text('Empathy'), findsOneWidget);
     expect(find.text('Can you tell me more about that?'), findsWidgets);
@@ -87,6 +89,7 @@ void main() {
 
     expect(repo.triggerCallCount, 1);
     expect(find.text('76'), findsOneWidget);
+    expect(find.textContaining('/100'), findsOneWidget);
   });
 
   testWidgets('shows 403 access denied', (tester) async {
@@ -159,5 +162,6 @@ void main() {
     await tester.pumpAndSettle();
     expect(repo.triggerCallCount, 2);
     expect(find.text('76'), findsOneWidget);
+    expect(find.textContaining('/100'), findsOneWidget);
   });
 }

--- a/frontend/test/features/evaluation/communication_panel_test.dart
+++ b/frontend/test/features/evaluation/communication_panel_test.dart
@@ -1,0 +1,163 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frontend/features/evaluation/presentation/communication_panel.dart';
+import '../../support/fake_communication_repository.dart';
+
+void main() {
+  testWidgets('shows analyzing skeleton while loading', (tester) async {
+    final gate = Completer<void>();
+    final repo = FakeCommunicationRepository(
+      onGet: () => gate.future,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Scaffold(
+          body: CommunicationPanel(
+            sessionId: 'ses-1',
+            communicationRepository: repo,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.textContaining('Analyzing your conversation'), findsNothing);
+    expect(find.textContaining('Checking for saved'), findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('76'), findsOneWidget);
+  });
+
+  testWidgets('success shows all criteria with quote', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Scaffold(
+          body: CommunicationPanel(
+            sessionId: 'ses-1',
+            communicationRepository: FakeCommunicationRepository(),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Communication coaching'), findsOneWidget);
+    expect(find.text('76'), findsOneWidget);
+    expect(find.text('Open-ended questions'), findsOneWidget);
+    expect(find.text('Empathy'), findsOneWidget);
+    expect(find.text('Can you tell me more about that?'), findsWidgets);
+  });
+
+  testWidgets('GET 409 not yet available triggers POST once', (tester) async {
+    final triggerGate = Completer<void>();
+    final repo = FakeCommunicationRepository(
+      getError: DioException(
+        requestOptions: RequestOptions(path: '/x'),
+        response: Response<dynamic>(
+          requestOptions: RequestOptions(path: '/x'),
+          statusCode: 409,
+          data: {'detail': 'Communication evaluation not yet available'},
+        ),
+        type: DioExceptionType.badResponse,
+      ),
+      onTrigger: () => triggerGate.future,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Scaffold(
+          body: CommunicationPanel(
+            sessionId: 'ses-1',
+            communicationRepository: repo,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.textContaining('reviewing your doctor'), findsOneWidget);
+    triggerGate.complete();
+    await tester.pumpAndSettle();
+
+    expect(repo.triggerCallCount, 1);
+    expect(find.text('76'), findsOneWidget);
+  });
+
+  testWidgets('shows 403 access denied', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Scaffold(
+          body: CommunicationPanel(
+            sessionId: 'ses-1',
+            communicationRepository: FakeCommunicationRepository(
+              getError: DioException(
+                requestOptions: RequestOptions(path: '/x'),
+                response: Response<void>(
+                  requestOptions: RequestOptions(path: '/x'),
+                  statusCode: 403,
+                ),
+                type: DioExceptionType.badResponse,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Access denied'), findsOneWidget);
+  });
+
+  testWidgets('502 retry triggers POST again', (tester) async {
+    var triggers = 0;
+    final repo = FakeCommunicationRepository(
+      getError: DioException(
+        requestOptions: RequestOptions(path: '/x'),
+        response: Response<dynamic>(
+          requestOptions: RequestOptions(path: '/x'),
+          statusCode: 409,
+          data: {'detail': 'Communication evaluation not yet available'},
+        ),
+        type: DioExceptionType.badResponse,
+      ),
+      onTrigger: () async {
+        triggers++;
+        if (triggers == 1) {
+          throw DioException(
+            requestOptions: RequestOptions(path: '/x'),
+            response: Response<void>(
+              requestOptions: RequestOptions(path: '/x'),
+              statusCode: 502,
+            ),
+            type: DioExceptionType.badResponse,
+          );
+        }
+      },
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Scaffold(
+          body: CommunicationPanel(
+            sessionId: 'ses-1',
+            communicationRepository: repo,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Communication coach unavailable'), findsOneWidget);
+
+    await tester.tap(find.text('Retry analysis'));
+    await tester.pumpAndSettle();
+    expect(repo.triggerCallCount, 2);
+    expect(find.text('76'), findsOneWidget);
+  });
+}

--- a/frontend/test/features/evaluation/debrief_screen_test.dart
+++ b/frontend/test/features/evaluation/debrief_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:frontend/features/evaluation/presentation/debrief_screen.dart';
 import 'package:frontend/network/openapi.dart' as g;
 
 import '../../support/fake_case_response.dart';
+import '../../support/fake_communication_repository.dart';
 
 g.DebriefResponse _minimalDebrief({
   BuiltList<g.EvaluationFindingResponse>? findings,
@@ -70,6 +71,7 @@ void main() {
           caseItem: fakeCaseResponse(),
           sessionId: 'ses-1',
           evaluationRepository: repo,
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -79,6 +81,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.textContaining('Total: 88'), findsOneWidget);
     expect(find.text('Scores'), findsOneWidget);
+    expect(find.text('Clinical'), findsOneWidget);
+    expect(find.text('Communication'), findsOneWidget);
   });
 
   testWidgets('success with empty findings', (WidgetTester tester) async {
@@ -88,6 +92,7 @@ void main() {
           caseItem: fakeCaseResponse(),
           sessionId: 'ses-1',
           evaluationRepository: _FakeEval(debrief: _minimalDebrief()),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -115,6 +120,7 @@ void main() {
               type: DioExceptionType.badResponse,
             ),
           ),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -139,6 +145,7 @@ void main() {
               type: DioExceptionType.badResponse,
             ),
           ),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -163,6 +170,7 @@ void main() {
               type: DioExceptionType.badResponse,
             ),
           ),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -187,6 +195,7 @@ void main() {
               type: DioExceptionType.badResponse,
             ),
           ),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );

--- a/frontend/test/features/sessions/unfinished_sessions_sheet_test.dart
+++ b/frontend/test/features/sessions/unfinished_sessions_sheet_test.dart
@@ -7,6 +7,7 @@ import 'package:frontend/domains/sessions/session_start_conflict.dart';
 import 'package:frontend/network/openapi.dart' as g;
 
 import '../../support/fake_case_response.dart';
+import '../../support/fake_communication_repository.dart';
 import '../../support/fake_session_repository.dart';
 
 void main() {
@@ -23,6 +24,7 @@ void main() {
                     context: context,
                     sessionRepository: FakeSessionRepository(),
                     evaluationRepository: FakeEvaluationRepository(),
+                    communicationRepository: FakeCommunicationRepository(),
                   ),
                   child: const Text('Open'),
                 ),
@@ -53,6 +55,7 @@ void main() {
                       activeItems: [fakeActiveSessionItem(sessionId: 's-1')],
                     ),
                     evaluationRepository: FakeEvaluationRepository(),
+                    communicationRepository: FakeCommunicationRepository(),
                   ),
                   child: const Text('Open'),
                 ),
@@ -87,6 +90,7 @@ void main() {
                       activeItems: [fakeActiveSessionItem(sessionId: 's-1')],
                     ),
                     evaluationRepository: FakeEvaluationRepository(),
+                    communicationRepository: FakeCommunicationRepository(),
                   ),
                   child: const Text('Open'),
                 ),
@@ -122,6 +126,7 @@ void main() {
                       onAbandon: (id) => abandoned = id,
                     ),
                     evaluationRepository: FakeEvaluationRepository(),
+                    communicationRepository: FakeCommunicationRepository(),
                   ),
                   child: const Text('Open'),
                 ),
@@ -164,6 +169,7 @@ void main() {
                       ),
                     ),
                     evaluationRepository: FakeEvaluationRepository(),
+                    communicationRepository: FakeCommunicationRepository(),
                   ),
                   child: const Text('Open'),
                 ),
@@ -195,6 +201,7 @@ void main() {
                     ),
                     sessionRepository: FakeSessionRepository(),
                     evaluationRepository: FakeEvaluationRepository(),
+                    communicationRepository: FakeCommunicationRepository(),
                   ),
                   child: const Text('Open'),
                 ),
@@ -240,6 +247,7 @@ void main() {
                       },
                     ),
                     evaluationRepository: FakeEvaluationRepository(),
+                    communicationRepository: FakeCommunicationRepository(),
                   ),
                   child: const Text('Open'),
                 ),

--- a/frontend/test/support/fake_communication_repository.dart
+++ b/frontend/test/support/fake_communication_repository.dart
@@ -1,0 +1,68 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:frontend/domains/evaluation/communication_repository.dart';
+import 'package:frontend/network/openapi.dart' as g;
+
+class FakeCommunicationRepository implements CommunicationRepositoryContract {
+  FakeCommunicationRepository({
+    this.evaluation,
+    this.getError,
+    this.triggerError,
+    this.onGet,
+    this.onTrigger,
+  });
+
+  final g.CommunicationEvaluationResponse? evaluation;
+  final Object? getError;
+  final Object? triggerError;
+  final Future<void> Function()? onGet;
+  final Future<void> Function()? onTrigger;
+
+  int getCallCount = 0;
+  int triggerCallCount = 0;
+
+  @override
+  Future<g.CommunicationEvaluationResponse> getCommunicationEvaluation({
+    required String sessionId,
+  }) async {
+    getCallCount++;
+    if (onGet != null) await onGet!();
+    if (getError != null) throw getError!;
+    return evaluation ?? fakeCommunicationEvaluation(sessionId: sessionId);
+  }
+
+  @override
+  Future<g.CommunicationEvaluationResponse> triggerCommunicationEvaluation({
+    required String sessionId,
+  }) async {
+    triggerCallCount++;
+    if (onTrigger != null) await onTrigger!();
+    if (triggerError != null) throw triggerError!;
+    return evaluation ?? fakeCommunicationEvaluation(sessionId: sessionId);
+  }
+}
+
+g.CommunicationEvaluationResponse fakeCommunicationEvaluation({
+  required String sessionId,
+}) {
+  return g.CommunicationEvaluationResponse((b) => b
+    ..sessionId = sessionId
+    ..model = 'mock'
+    ..promptVersion = 'v1'
+    ..totalScore = 76
+    ..createdAt = DateTime.utc(2026, 6, 19, 12)
+    ..criteria.replace(BuiltList<g.CommunicationCriterionResponse>([
+      _criterion('open_ended_questions', 4),
+      _criterion('empathy', 4),
+      _criterion('structured_history', 3),
+      _criterion('closing_the_loop', 4),
+      _criterion('no_leading_questions', 3),
+    ])));
+}
+
+g.CommunicationCriterionResponse _criterion(String key, int score) {
+  return g.CommunicationCriterionResponse((b) => b
+    ..criterion = key
+    ..score = score
+    ..rationale = 'Feedback for $key.'
+    ..quote = 'Can you tell me more about that?');
+}

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -11,6 +11,7 @@ import 'package:frontend/features/cases/presentation/case_simulation_screen.dart
 import 'package:frontend/network/openapi.dart' as generated;
 
 import 'support/fake_case_response.dart';
+import 'support/fake_communication_repository.dart';
 
 void main() {
   testWidgets('CaseSimulationScreen renders with chat UI',
@@ -23,6 +24,7 @@ void main() {
           sessionId: 'test-session-abc123',
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -40,6 +42,7 @@ void main() {
           caseRepository: _FakeCaseRepository(),
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -60,6 +63,7 @@ void main() {
           caseRepository: _FakeCaseRepository(),
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -82,6 +86,7 @@ void main() {
           caseRepository: _FakeCaseRepository(),
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -114,6 +119,7 @@ void main() {
           caseRepository: _FakeCaseRepository(),
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );
@@ -143,6 +149,7 @@ void main() {
           caseRepository: _FakeCaseRepository(),
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
+          communicationRepository: FakeCommunicationRepository(),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Regenerates the Flutter OpenAPI client with `CommunicationEvaluationApi` and related models from the #69 backend.
- Adds a tabbed debrief screen (Clinical | Communication) with a polished Communication panel that GETs saved scores or auto-triggers the LLM judge on 409 "not yet available".
- Wires `CommunicationRepository` through app DI and navigation; includes widget tests for panel states and debrief tabs.

Closes https://github.com/virtual-ai-patient/platform/issues/72

## Test plan
- [ ] `cd frontend && dart format . && flutter analyze && flutter test` (25 tests pass)
- [ ] Finish a case → debrief opens on Clinical tab
- [ ] Switch to Communication → skeleton → scores appear
- [ ] Re-open debrief on same session → GET 200 only, no duplicate POST


Made with [Cursor](https://cursor.com)