### PR TITLE
Backend: analytics + student-actions export API (CSV/JSON)

### DIFF
--- a/backend/analytics/export.py
+++ b/backend/analytics/export.py
@@ -1,0 +1,50 @@
+import csv
+import io
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+from pydantic import BaseModel
+
+_INJECTION_PREFIXES = ("=", "+", "-", "@")
+
+
+def _sanitize_cell(value: Any) -> str:
+    if isinstance(value, dict | list):
+        text = json.dumps(value, sort_keys=True)
+    elif value is None:
+        text = ""
+    else:
+        text = str(value)
+    if text and text[0] in _INJECTION_PREFIXES:
+        return "'" + text
+    return text
+
+
+async def stream_csv(
+    fieldnames: list[str], rows: AsyncIterator[BaseModel]
+) -> AsyncIterator[str]:
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, lineterminator="\r\n")
+    writer.writerow(fieldnames)
+    yield buffer.getvalue()
+    buffer.seek(0)
+    buffer.truncate(0)
+
+    async for row in rows:
+        data = row.model_dump(mode="json")
+        writer.writerow([_sanitize_cell(data[name]) for name in fieldnames])
+        yield buffer.getvalue()
+        buffer.seek(0)
+        buffer.truncate(0)
+
+
+async def stream_json(rows: AsyncIterator[BaseModel]) -> AsyncIterator[str]:
+    yield "["
+    first = True
+    async for row in rows:
+        if not first:
+            yield ","
+        first = False
+        yield row.model_dump_json()
+    yield "]"

--- a/backend/analytics/repository.py
+++ b/backend/analytics/repository.py
@@ -1,0 +1,261 @@
+import json
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from analytics.response import ActionExportRow, SessionExportRow
+from models.db import (
+    ActionLog,
+    CaseSession,
+    ClinicalCase,
+    Evaluation,
+    EvaluationFinding,
+    User,
+)
+
+_PAGE_SIZE = 500
+
+
+def _derive_action(role: str, content: str) -> tuple[str, dict[str, Any]]:
+    if role == "user":
+        return "chat_user", {"text": content}
+    if role == "assistant":
+        return "chat_assistant", {"text": content}
+    if role == "system" and content.startswith("TEST_ORDERED:"):
+        return "order_test", {"test_id": content.split(":", 1)[1]}
+    try:
+        parsed = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        parsed = None
+    if isinstance(parsed, dict) and isinstance(parsed.get("action"), str):
+        action_type = str(parsed["action"])
+        payload = {k: v for k, v in parsed.items() if k != "action"}
+        return action_type, payload
+    return role, {"raw": content}
+
+
+class _SessionPageRow:
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        case_id: str,
+        case_version: int | None,
+        learner_id: str,
+        started_at: datetime,
+        finished_at: datetime | None,
+        total_score: float | None,
+        score_diagnosis: float | None,
+        score_diagnostics: float | None,
+        score_treatment: float | None,
+        score_safety: float | None,
+    ) -> None:
+        self.session_id = session_id
+        self.case_id = case_id
+        self.case_version = case_version
+        self.learner_id = learner_id
+        self.started_at = started_at
+        self.finished_at = finished_at
+        self.total_score = total_score
+        self.score_diagnosis = score_diagnosis
+        self.score_diagnostics = score_diagnostics
+        self.score_treatment = score_treatment
+        self.score_safety = score_safety
+
+
+class AnalyticsRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def iter_session_rows(
+        self,
+        *,
+        learner_id: str | None,
+        since: datetime | None,
+        until: datetime | None,
+        page_size: int = _PAGE_SIZE,
+    ) -> AsyncIterator[SessionExportRow]:
+        offset = 0
+        while True:
+            page = await self._fetch_session_page(
+                learner_id, since, until, offset, page_size
+            )
+            if not page:
+                return
+            session_ids = [row.session_id for row in page]
+            findings_by_session = await self._fetch_findings_by_severity(session_ids)
+            for row in page:
+                yield SessionExportRow(
+                    session_id=row.session_id,
+                    case_id=row.case_id,
+                    case_version=row.case_version,
+                    learner_id=row.learner_id,
+                    started_at=row.started_at,
+                    finished_at=row.finished_at,
+                    total_score=row.total_score,
+                    score_diagnosis=row.score_diagnosis,
+                    score_diagnostics=row.score_diagnostics,
+                    score_treatment=row.score_treatment,
+                    score_safety=row.score_safety,
+                    findings_by_severity=findings_by_session.get(row.session_id, {}),
+                )
+            if len(page) < page_size:
+                return
+            offset += page_size
+
+    async def _fetch_session_page(
+        self,
+        learner_id: str | None,
+        since: datetime | None,
+        until: datetime | None,
+        offset: int,
+        page_size: int,
+    ) -> list[_SessionPageRow]:
+        query = (
+            select(
+                CaseSession.session_id,
+                ClinicalCase.case_id.label("case_id"),
+                Evaluation.case_version.label("case_version"),
+                User.username.label("learner_id"),
+                CaseSession.created_at.label("started_at"),
+                CaseSession.status.label("status"),
+                CaseSession.last_activity_at.label("finished_at"),
+                Evaluation.total_score.label("total_score"),
+                Evaluation.score_diagnosis.label("score_diagnosis"),
+                Evaluation.score_diagnostics.label("score_diagnostics"),
+                Evaluation.score_treatment.label("score_treatment"),
+                Evaluation.score_safety.label("score_safety"),
+            )
+            .join(User, User.id == CaseSession.user_id)
+            .join(ClinicalCase, ClinicalCase.id == CaseSession.clinical_case_id)
+            .outerjoin(Evaluation, Evaluation.session_id == CaseSession.session_id)
+        )
+        if learner_id is not None:
+            query = query.where(User.username == learner_id)
+        if since is not None:
+            query = query.where(CaseSession.created_at >= since)
+        if until is not None:
+            query = query.where(CaseSession.created_at <= until)
+
+        query = query.order_by(CaseSession.session_id).offset(offset).limit(page_size)
+        result = await self._session.execute(query)
+        rows = result.all()
+        return [
+            _SessionPageRow(
+                session_id=r.session_id,
+                case_id=r.case_id,
+                case_version=r.case_version,
+                learner_id=r.learner_id,
+                started_at=r.started_at,
+                finished_at=(
+                    r.finished_at if r.status in ("completed", "abandoned") else None
+                ),
+                total_score=r.total_score,
+                score_diagnosis=r.score_diagnosis,
+                score_diagnostics=r.score_diagnostics,
+                score_treatment=r.score_treatment,
+                score_safety=r.score_safety,
+            )
+            for r in rows
+        ]
+
+    async def _fetch_findings_by_severity(
+        self, session_ids: list[str]
+    ) -> dict[str, dict[str, int]]:
+        if not session_ids:
+            return {}
+        result = await self._session.execute(
+            select(
+                Evaluation.session_id,
+                EvaluationFinding.severity,
+                func.count().label("count"),
+            )
+            .join(EvaluationFinding, EvaluationFinding.evaluation_id == Evaluation.id)
+            .where(Evaluation.session_id.in_(session_ids))
+            .group_by(Evaluation.session_id, EvaluationFinding.severity)
+        )
+        out: dict[str, dict[str, int]] = {}
+        for session_id, severity, count in result.all():
+            out.setdefault(session_id, {})[severity] = int(count)
+        return out
+
+    async def iter_action_rows(
+        self,
+        *,
+        session_id: str | None,
+        learner_id: str | None,
+        since: datetime | None,
+        until: datetime | None,
+        page_size: int = _PAGE_SIZE,
+    ) -> AsyncIterator[ActionExportRow]:
+        offset = 0
+        while True:
+            page = await self._fetch_action_page(
+                session_id, learner_id, since, until, offset, page_size
+            )
+            if not page:
+                return
+            for row in page:
+                action_type, payload = _derive_action(row.role, row.content)
+                yield ActionExportRow(
+                    session_id=row.session_id,
+                    learner_id=row.learner_id,
+                    turn_index=row.turn_index,
+                    timestamp=row.created_at,
+                    action_type=action_type,
+                    payload_json=payload,
+                )
+            if len(page) < page_size:
+                return
+            offset += page_size
+
+    async def _fetch_action_page(
+        self,
+        session_id: str | None,
+        learner_id: str | None,
+        since: datetime | None,
+        until: datetime | None,
+        offset: int,
+        page_size: int,
+    ) -> list[Any]:
+        turn_index = (
+            func.row_number()
+            .over(
+                partition_by=ActionLog.session_id,
+                order_by=ActionLog.created_at,
+            )
+            .label("turn_index")
+        )
+        query = (
+            select(
+                ActionLog.session_id,
+                User.username.label("learner_id"),
+                ActionLog.role,
+                ActionLog.content,
+                ActionLog.created_at,
+                (turn_index - 1).label("turn_index"),
+            )
+            .join(CaseSession, CaseSession.session_id == ActionLog.session_id)
+            .join(User, User.id == CaseSession.user_id)
+        )
+        if session_id is not None:
+            query = query.where(ActionLog.session_id == session_id)
+        if learner_id is not None:
+            query = query.where(User.username == learner_id)
+        if since is not None:
+            query = query.where(ActionLog.created_at >= since)
+        if until is not None:
+            query = query.where(ActionLog.created_at <= until)
+
+        subquery = query.subquery()
+        paged = (
+            select(subquery)
+            .order_by(subquery.c.session_id, subquery.c.turn_index)
+            .offset(offset)
+            .limit(page_size)
+        )
+        result = await self._session.execute(paged)
+        return list(result.all())

--- a/backend/analytics/response.py
+++ b/backend/analytics/response.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SessionExportRow(BaseModel):
+    session_id: str
+    case_id: str
+    case_version: int | None
+    learner_id: str
+    started_at: datetime
+    finished_at: datetime | None
+    total_score: float | None
+    score_diagnosis: float | None
+    score_diagnostics: float | None
+    score_treatment: float | None
+    score_safety: float | None
+    findings_by_severity: dict[str, int]
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "session_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "case_id": "CASE-001",
+                    "case_version": 1,
+                    "learner_id": "learner",
+                    "started_at": "2026-06-14T11:45:00Z",
+                    "finished_at": "2026-06-14T12:00:00Z",
+                    "total_score": 82.5,
+                    "score_diagnosis": 100.0,
+                    "score_diagnostics": 75.0,
+                    "score_treatment": 80.0,
+                    "score_safety": 100.0,
+                    "findings_by_severity": {"major": 1, "minor": 2},
+                }
+            ]
+        }
+    )
+
+
+class ActionExportRow(BaseModel):
+    session_id: str
+    learner_id: str
+    turn_index: int
+    timestamp: datetime
+    action_type: str
+    payload_json: dict[str, Any]
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "session_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "learner_id": "learner",
+                    "turn_index": 0,
+                    "timestamp": "2026-06-14T11:45:03Z",
+                    "action_type": "chat_user",
+                    "payload_json": {"text": "Where does it hurt?"},
+                }
+            ]
+        }
+    )

--- a/backend/analytics/router.py
+++ b/backend/analytics/router.py
@@ -1,0 +1,109 @@
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from analytics.export import stream_csv, stream_json
+from analytics.repository import AnalyticsRepository
+from analytics.response import ActionExportRow, SessionExportRow
+from dependencies import get_current_user, get_db
+from models.db import User
+from sessions.repository import SessionRepository
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+_SESSION_FIELDS = list(SessionExportRow.model_fields.keys())
+_ACTION_FIELDS = list(ActionExportRow.model_fields.keys())
+
+
+def get_analytics_repo(db: AsyncSession = Depends(get_db)) -> AnalyticsRepository:
+    return AnalyticsRepository(db)
+
+
+def get_session_repo(db: AsyncSession = Depends(get_db)) -> SessionRepository:
+    return SessionRepository(db)
+
+
+def _to_response(
+    format: Literal["csv", "json"],
+    fieldnames: list[str],
+    rows: AsyncIterator[SessionExportRow] | AsyncIterator[ActionExportRow],
+    filename: str,
+) -> StreamingResponse:
+    if format == "csv":
+        return StreamingResponse(
+            stream_csv(fieldnames, rows),
+            media_type="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{filename}.csv"'},
+        )
+    return StreamingResponse(
+        stream_json(rows),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}.json"'},
+    )
+
+
+@router.get("/export/sessions")
+async def export_sessions(
+    format: Literal["csv", "json"] = Query("csv"),
+    scope: Literal["me", "all"] = Query("me"),
+    since: datetime | None = Query(None),
+    until: datetime | None = Query(None),
+    current_user: User = Depends(get_current_user),
+    repo: AnalyticsRepository = Depends(get_analytics_repo),
+) -> StreamingResponse:
+    if scope == "all" and current_user.role not in ("educator", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Educator or admin role required to export cohort scope",
+        )
+
+    learner_id = None if scope == "all" else current_user.username
+    rows = repo.iter_session_rows(learner_id=learner_id, since=since, until=until)
+    return _to_response(format, _SESSION_FIELDS, rows, "sessions_export")
+
+
+@router.get("/export/actions")
+async def export_actions(
+    format: Literal["csv", "json"] = Query("csv"),
+    session_id: str | None = Query(None),
+    since: datetime | None = Query(None),
+    until: datetime | None = Query(None),
+    current_user: User = Depends(get_current_user),
+    repo: AnalyticsRepository = Depends(get_analytics_repo),
+    session_repo: SessionRepository = Depends(get_session_repo),
+) -> StreamingResponse:
+    if session_id is not None:
+        session = await session_repo.get_by_session_id(session_id)
+        if session is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Session '{session_id}' not found",
+            )
+        if session.user_id != current_user.id and current_user.role not in (
+            "educator",
+            "admin",
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have access to this session",
+            )
+        learner_filter = None
+    else:
+        if current_user.role not in ("educator", "admin"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Educator or admin role required to export cohort actions",
+            )
+        learner_filter = None
+
+    rows = repo.iter_action_rows(
+        session_id=session_id,
+        learner_id=learner_filter,
+        since=since,
+        until=until,
+    )
+    return _to_response(format, _ACTION_FIELDS, rows, "actions_export")

--- a/backend/server.py
+++ b/backend/server.py
@@ -19,6 +19,7 @@ from config import (
 )
 from repositories.user_repository import UserRepository
 from admin.router import router as admin_router
+from analytics.router import router as analytics_router
 from cases.router import router as cases_router
 from routers import login, refresh, reset_password, signup, verify
 from sessions.router import router as sessions_router
@@ -89,3 +90,4 @@ app.include_router(reset_password.router, prefix="/auth", tags=["auth"])
 app.include_router(cases_router)
 app.include_router(sessions_router)
 app.include_router(admin_router)
+app.include_router(analytics_router)

--- a/backend/tests/test_analytics_export.py
+++ b/backend/tests/test_analytics_export.py
@@ -1,0 +1,501 @@
+"""Integration tests for GET /analytics/export/sessions and /analytics/export/actions (#93)."""
+
+import asyncio
+import csv
+import io
+import json
+import os
+from typing import Any, cast
+
+os.environ.setdefault("USE_MOCK_AI", "true")
+
+from fastapi.testclient import TestClient
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+import models.database as database
+from analytics.repository import AnalyticsRepository
+from models.db import ClinicalCase
+
+
+def _minimal_case(case_id: str = "analytics_case_001") -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "title": "Acute chest pain",
+        "language": "en",
+        "difficulty": "medium",
+        "specialty": "emergency_medicine",
+        "tags": ["chest_pain"],
+        "age": 54,
+        "sex": "male",
+        "persona": "Worried delivery driver.",
+        "tone_presets": ["neutral"],
+        "chief_complaint": "Chest pain",
+        "history_of_present_illness": "Substernal pressure for 45 minutes.",
+        "key_history_points": {
+            "must_ask": ["Onset and duration"],
+            "nice_to_ask": ["Recent exertion"],
+            "red_flags": ["Syncope"],
+        },
+        "final_diagnosis": "STEMI",
+        "differential": ["STEMI", "Unstable angina"],
+        "severity_or_stage": None,
+        "investigations": {
+            "catalog_hints": ["ECG"],
+            "expected": {
+                "must_order": ["ECG"],
+                "optional": [],
+                "should_not_order": [],
+            },
+            "results": [
+                {
+                    "test_name": "ECG",
+                    "result_type": "text_report",
+                    "value": "ST elevation.",
+                    "unit": None,
+                    "reference_range": None,
+                }
+            ],
+        },
+        "management": {
+            "diagnostic_plan": ["Immediate ECG"],
+            "treatment_plan": ["Activate cath lab"],
+            "contraindications": [],
+            "follow_up": [],
+        },
+        "scoring": {
+            "weight_diagnosis": 0.35,
+            "weight_diagnostics": 0.25,
+            "weight_treatment": 0.30,
+            "weight_safety": 0.10,
+            "acceptable_answers": [{"field": "final_diagnosis", "answer": "STEMI"}],
+            "critical_safety_errors": [],
+        },
+    }
+
+
+def _publish_case(case_id: str) -> None:
+    async def _run() -> None:
+        session_factory = cast(
+            async_sessionmaker[AsyncSession],
+            database._TestSessionLocal,  # type: ignore[attr-defined]
+        )
+        async with session_factory() as session:
+            await session.execute(
+                update(ClinicalCase)
+                .where(ClinicalCase.case_id == case_id)
+                .values(status="published")
+            )
+            await session.commit()
+
+    asyncio.run(_run())
+
+
+def _create_case(
+    client: TestClient, educator_headers: dict[str, str], case_id: str
+) -> str:
+    r = client.post("/cases", json=_minimal_case(case_id), headers=educator_headers)
+    assert r.status_code == 201
+    _publish_case(case_id)
+    return case_id
+
+
+def _start_chat_and_finish(
+    client: TestClient, headers: dict[str, str], case_id: str
+) -> str:
+    """Start a session, exchange one chat turn, order a test, submit conclusions,
+    and finish (triggering auto-scoring). Returns the session_id."""
+    start = client.post("/sessions/start", json={"case_id": case_id}, headers=headers)
+    assert start.status_code == 201
+    session_id: str = start.json()["session_id"]
+
+    chat = client.post(
+        f"/sessions/{session_id}/chat",
+        json={"message": "Where does it hurt?"},
+        headers=headers,
+    )
+    assert chat.status_code == 200
+
+    order = client.post(
+        f"/sessions/{session_id}/order-test",
+        json={"test_id": "ECG"},
+        headers=headers,
+    )
+    assert order.status_code == 200
+
+    patch = client.patch(
+        f"/sessions/{session_id}/conclusions",
+        json={
+            "final_diagnosis": "STEMI",
+            "treatment_plan": {
+                "medications": [{"name": "Activate cath lab", "dose": "", "route": ""}],
+                "non_pharmacological": ["Immediate ECG"],
+                "referrals": [],
+                "follow_up": [],
+            },
+        },
+        headers=headers,
+    )
+    assert patch.status_code == 200
+
+    finish = client.post(f"/sessions/{session_id}/finish", headers=headers)
+    assert finish.status_code == 200
+    return session_id
+
+
+# ---------------------------------------------------------------------------
+# GET /analytics/export/sessions
+# ---------------------------------------------------------------------------
+
+
+class TestExportSessions:
+    def test_learner_can_export_own_sessions_csv(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_sessions_1")
+        session_id = _start_chat_and_finish(client, learner_headers, case_id)
+
+        r = client.get("/analytics/export/sessions", headers=learner_headers)
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("text/csv")
+
+        reader = csv.reader(io.StringIO(r.text))
+        rows = list(reader)
+        header, data_rows = rows[0], rows[1:]
+        assert "session_id" in header
+        assert any(row[header.index("session_id")] == session_id for row in data_rows)
+
+    def test_learner_scope_all_forbidden(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_sessions_2")
+        _start_chat_and_finish(client, learner_headers, case_id)
+
+        r = client.get("/analytics/export/sessions?scope=all", headers=learner_headers)
+        assert r.status_code == 403
+
+    def test_educator_scope_all_sees_other_learners(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_sessions_3")
+        session_id = _start_chat_and_finish(client, learner_headers, case_id)
+
+        r = client.get("/analytics/export/sessions?scope=all", headers=educator_headers)
+        assert r.status_code == 200
+        reader = csv.reader(io.StringIO(r.text))
+        rows = list(reader)
+        header, data_rows = rows[0], rows[1:]
+        assert any(row[header.index("session_id")] == session_id for row in data_rows)
+
+    def test_json_format_includes_scores_and_findings(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_sessions_4")
+        session_id = _start_chat_and_finish(client, learner_headers, case_id)
+
+        r = client.get(
+            "/analytics/export/sessions?format=json", headers=learner_headers
+        )
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("application/json")
+        rows = r.json()
+        row = next(row for row in rows if row["session_id"] == session_id)
+        assert row["total_score"] is not None
+        assert row["case_version"] == 1
+        assert isinstance(row["findings_by_severity"], dict)
+
+    def test_determinism_same_window_same_bytes(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_sessions_5")
+        _start_chat_and_finish(client, learner_headers, case_id)
+
+        r1 = client.get("/analytics/export/sessions", headers=learner_headers)
+        r2 = client.get("/analytics/export/sessions", headers=learner_headers)
+        assert r1.content == r2.content
+
+    def test_empty_window_returns_header_only(
+        self,
+        client: TestClient,
+        learner_headers: dict[str, str],
+    ) -> None:
+        r = client.get(
+            "/analytics/export/sessions?since=2099-01-01T00:00:00Z",
+            headers=learner_headers,
+        )
+        assert r.status_code == 200
+        reader = csv.reader(io.StringIO(r.text))
+        rows = list(reader)
+        assert len(rows) == 1  # header only
+
+    def test_unauthenticated_rejected(self, client: TestClient) -> None:
+        r = client.get("/analytics/export/sessions")
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /analytics/export/actions
+# ---------------------------------------------------------------------------
+
+
+class TestExportActions:
+    def test_owner_can_export_own_session_actions(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_actions_1")
+        session_id = _start_chat_and_finish(client, learner_headers, case_id)
+
+        r = client.get(
+            f"/analytics/export/actions?session_id={session_id}",
+            headers=learner_headers,
+        )
+        assert r.status_code == 200
+        reader = csv.reader(io.StringIO(r.text))
+        rows = list(reader)
+        header, data_rows = rows[0], rows[1:]
+        assert "action_type" in header
+        action_types = {row[header.index("action_type")] for row in data_rows}
+        assert "chat_user" in action_types
+        assert "chat_assistant" in action_types
+        assert "order_test" in action_types
+
+    def test_other_learner_cannot_export_session_actions(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_actions_2")
+        session_id = _start_chat_and_finish(client, learner_headers, case_id)
+
+        _insert_second_learner(client)
+        other_headers = _login(client, "learner_two")
+
+        r = client.get(
+            f"/analytics/export/actions?session_id={session_id}",
+            headers=other_headers,
+        )
+        assert r.status_code == 403
+
+    def test_educator_can_export_any_session_actions(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_actions_3")
+        session_id = _start_chat_and_finish(client, learner_headers, case_id)
+
+        r = client.get(
+            f"/analytics/export/actions?session_id={session_id}",
+            headers=educator_headers,
+        )
+        assert r.status_code == 200
+
+    def test_learner_cannot_bulk_export_actions(
+        self,
+        client: TestClient,
+        learner_headers: dict[str, str],
+    ) -> None:
+        r = client.get("/analytics/export/actions", headers=learner_headers)
+        assert r.status_code == 403
+
+    def test_educator_bulk_export_actions(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_actions_4")
+        _start_chat_and_finish(client, learner_headers, case_id)
+
+        r = client.get("/analytics/export/actions", headers=educator_headers)
+        assert r.status_code == 200
+        reader = csv.reader(io.StringIO(r.text))
+        rows = list(reader)
+        assert len(rows) > 1  # header + at least one row
+
+    def test_session_not_found(
+        self,
+        client: TestClient,
+        learner_headers: dict[str, str],
+    ) -> None:
+        r = client.get(
+            "/analytics/export/actions?session_id=nonexistent",
+            headers=learner_headers,
+        )
+        assert r.status_code == 404
+
+    def test_turn_index_is_chronological(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        case_id = _create_case(client, educator_headers, "analytics_actions_5")
+        session_id = _start_chat_and_finish(client, learner_headers, case_id)
+
+        r = client.get(
+            f"/analytics/export/actions?session_id={session_id}&format=json",
+            headers=learner_headers,
+        )
+        rows = r.json()
+        turn_indices = [row["turn_index"] for row in rows]
+        assert turn_indices == sorted(turn_indices)
+        assert turn_indices[0] == 0
+
+    def test_spreadsheet_injection_neutralised_end_to_end(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        """payload_json cells are always JSON objects (leading '{'), which
+        spreadsheet apps never treat as a formula trigger — so the injection
+        risk is on scalar cells (e.g. learner_id) instead. Seed a case_id
+        that itself starts with a formula-trigger character via a raw DB
+        write to CaseSession's joined ClinicalCase, which is out of scope
+        here; instead this covers the payload path end-to-end and the unit
+        test below covers the neutralisation guarantee directly."""
+        case_id = _create_case(client, educator_headers, "analytics_actions_6")
+        start = client.post(
+            "/sessions/start", json={"case_id": case_id}, headers=learner_headers
+        )
+        session_id = start.json()["session_id"]
+
+        chat = client.post(
+            f"/sessions/{session_id}/chat",
+            json={"message": "=cmd|'/c calc'!A0"},
+            headers=learner_headers,
+        )
+        assert chat.status_code == 200
+
+        r = client.get(
+            f"/analytics/export/actions?session_id={session_id}",
+            headers=learner_headers,
+        )
+        reader = csv.reader(io.StringIO(r.text))
+        rows = list(reader)
+        header = rows[0]
+        payload_col = header.index("payload_json")
+        matching = [row for row in rows[1:] if "cmd" in row[payload_col]]
+        assert matching
+        payload = json.loads(matching[0][payload_col])
+        assert payload["text"].startswith("=cmd")
+
+
+class TestSanitizeCell:
+    """Unit tests for the RFC-4180 + spreadsheet-injection CSV cell guard."""
+
+    def test_leading_equals_is_neutralised(self) -> None:
+        from analytics.export import _sanitize_cell
+
+        assert _sanitize_cell("=cmd|'/c calc'!A0") == "'=cmd|'/c calc'!A0"
+
+    def test_leading_plus_minus_at_are_neutralised(self) -> None:
+        from analytics.export import _sanitize_cell
+
+        assert _sanitize_cell("+1").startswith("'")
+        assert _sanitize_cell("-1").startswith("'")
+        assert _sanitize_cell("@SUM(A1)").startswith("'")
+
+    def test_benign_values_are_untouched(self) -> None:
+        from analytics.export import _sanitize_cell
+
+        assert _sanitize_cell("chat_user") == "chat_user"
+        assert _sanitize_cell(None) == ""
+
+    def test_dict_payload_serialised_as_json(self) -> None:
+        from analytics.export import _sanitize_cell
+
+        assert _sanitize_cell({"text": "=cmd"}) == '{"text": "=cmd"}'
+
+
+def _insert_second_learner(client: TestClient) -> None:
+    signup = client.post(
+        "/auth/signup",
+        json={
+            "username": "learner_two",
+            "email": "learner_two@example.com",
+            "password": "secret123",
+        },
+    )
+    assert signup.status_code in (200, 201)
+
+
+def _login(client: TestClient, username: str) -> dict[str, str]:
+    tokens: dict[str, str] = client.post(
+        "/auth/login",
+        data={"username": username, "password": "secret123"},
+    ).json()
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+# ---------------------------------------------------------------------------
+# Repository-level pagination correctness (streaming guarantee)
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyticsRepositoryPagination:
+    def test_iter_action_rows_paginates_without_gaps_or_duplicates(
+        self,
+        client: TestClient,
+        educator_headers: dict[str, str],
+        learner_headers: dict[str, str],
+    ) -> None:
+        """Seed many action-log rows and confirm a small page_size still yields
+        every row exactly once, in order — the guarantee the export streaming
+        relies on to avoid materialising the full result set at once."""
+        case_id = _create_case(client, educator_headers, "analytics_pagination_1")
+        start = client.post(
+            "/sessions/start", json={"case_id": case_id}, headers=learner_headers
+        )
+        session_id = start.json()["session_id"]
+
+        for i in range(25):
+            chat = client.post(
+                f"/sessions/{session_id}/chat",
+                json={"message": f"question {i}"},
+                headers=learner_headers,
+            )
+            assert chat.status_code == 200
+
+        async def _run() -> list[int]:
+            session_factory = cast(
+                async_sessionmaker[AsyncSession],
+                database._TestSessionLocal,  # type: ignore[attr-defined]
+            )
+            async with session_factory() as session:
+                repo = AnalyticsRepository(session)
+                turn_indices = []
+                async for row in repo.iter_action_rows(
+                    session_id=session_id,
+                    learner_id=None,
+                    since=None,
+                    until=None,
+                    page_size=3,
+                ):
+                    turn_indices.append(row.turn_index)
+                return turn_indices
+
+        turn_indices = asyncio.run(_run())
+        assert turn_indices == list(range(len(turn_indices)))
+        assert len(turn_indices) == 50  # 25 user + 25 assistant turns


### PR DESCRIPTION
## Summary
- Adds `GET /analytics/export/sessions` and `GET /analytics/export/actions` — streaming CSV/JSON export of session scores and the learner-action trace, closes #93.
- RBAC: `scope=me`/own-session export for any authenticated role; `scope=all`/cohort-wide export requires `educator`/`admin`.
- Streams via `StreamingResponse` over a paginated async generator (500-row pages) so nothing is fully materialized in memory; CSV cells are RFC-4180 written with a leading `=+-@` guard against spreadsheet injection.

## Notes on scope vs. the original issue text
- No `/v1` prefix — nothing else in this API is versioned, so `/analytics/...` matches the existing `/admin`, `/cases`, `/sessions` convention.
- No `cohort_id` — there's no cohort/class model in the schema, so cohort-scope became `scope=all` (educator/admin, all learners), matching how `/admin/sessions` already works.
- No schema migration — `action_logs` only stores `role`/`content`. `action_type`/`payload_json` are reconstructed from the existing logging conventions already in use (chat turns, `TEST_ORDERED:` markers, `{"action": ...}` JSON blobs for conclusions/finish/abandon), so export works against real data with no migration risk.

## Test plan
- [x] `ruff check .` and `mypy --strict .` clean
- [x] New `backend/tests/test_analytics_export.py` (20 tests): RBAC (learner/educator/admin, 403/404), CSV/JSON round-trip, determinism (byte-identical repeat calls), empty-window edge case, spreadsheet-injection neutralization, turn ordering, pagination correctness
- [x] Full backend suite: 189 passed, 92.4% coverage (≥80% required)
- [x] Confirmed both routes appear in the FastAPI OpenAPI schema