### PR TITLE
docs: align proposal context and record expert interviews

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,35 +1,52 @@
 # Virtual AI Patient — Documentation
 
-This folder contains **product, market, and specification documents** for the *Virtual AI Patient* project. Source code lives in `backend/`, `bot/`, and `frontend/`.
+This folder contains product, proposal, market, architecture, and specification
+documents for the Virtual AI Patient project. Source code lives in the backend,
+bot, and frontend directories.
 
 ## What we are building
-Medical students and early-career physicians often lack a safe way to practice **clinical communication and diagnostic reasoning** before real patient encounters. Typical learning cases are static and do not provide experience of a real dialogue.
 
-We are building a chat-based training platform with **virtual AI patients** that behave like real patients: they complain, answer questions, may be emotional or incomplete, and provide **clinically plausible** histories and findings. A learner can request laboratory and instrumental investigations and receive **realistic results**. After finishing a case, the system highlights mistakes and shows a reference (gold) solution.
+Medical students and early-career doctors need a safe way to practise clinical
+communication and diagnostic reasoning before real-patient encounters. Static
+cases do not reproduce the uncertainty, emotion, and incomplete information of
+a real consultation.
+
+The project explores a chat-based simulator with virtual patients who reveal
+information progressively, may be emotional or unreliable, and remain
+consistent with a structured clinical case. Learners can request investigations,
+make diagnostic and management decisions, and receive a debrief against a
+reviewed reference solution.
+
+## Proposal context
+
+The current course deliverable is a startup proposal backed by a validated
+prototype. The proposal focuses on technical evidence for three areas: patient
+role realism, a constrained clinical-case system, and game-like diagnostic
+practice. Business modelling and financial projections are outside the
+software-engineering course scope.
 
 ## Key capabilities
-- **Dynamic dialogue** with controllable tone (neutral, anxious, angry, etc.)
-- **Multiple conditions / nosologies**, expandable case library
-- **Orders & results** for labs/instrumental tests, including plausible generated results if not present in the original case
-- **Automated evaluation**: diagnosis, diagnostic plan, and treatment plan alignment with a gold standard
-- **Clinical case ingestion pipeline** for scalable content creation
-- **Integration-ready APIs** for embedding into an existing physician platform
-- Optional: **cost-of-care** layer (pricing of investigations and treatments)
 
-## Target milestone (6 months)
-- Launch an MVP-to-pilot platform with:
-  - **3** realistic, dynamic clinical cases
-  - investigation result generation module
-  - automated assessment of learner decisions
-  - pilot deployment on a physicians’ platform (integration aligned with partner team)
+- **Dynamic patient dialogue** with partial recall, uncertainty, and controlled
+  emotional states.
+- **Structured clinical cases** with ground truth, compatible investigations,
+  prices, and resource limits.
+- **Investigation ordering and results** that remain plausible for the active
+  case and timeline.
+- **Automated debriefing** for diagnosis, investigation choices, safety,
+  management, and reasoning bias.
+- **Reusable case authoring** with validation and review status.
+- **Prototype interfaces and APIs** for testing the complete learning loop.
 
 ## Documents
-- **Technical product description**: `product/technical-product-description.md`
-- **Market assessment**: `market/market-assessment.md`
-- **Technical specification (incl. quality metrics)**: `spec/technical-specification.md`
-- **Quality Attributes** : `qa/qa-rev{N}.md`
-- **Sprint documents**: `sprints/sprint{N}/`
-- **System architecture (supporting)**: `architecture/system-architecture.md`
-- **Clinical case data format (supporting)**: `data/clinical-case-format.md`
-- **Integration notes (supporting)**: `integrations/integration-overview.md`
-- **Configuration Management rules**: `cm/configuration-management.md`
+
+- [Technical product description](product/technical-product-description.md)
+- [User insights](proposal/user-insights.md)
+- [Market assessment](market/market-assessment.md)
+- [Technical specification](spec/technical-specification.md)
+- [Quality attributes](qa/)
+- [Sprint documents](sprints/)
+- [System architecture](architecture/system-architecture.md)
+- [Clinical case data format](data/clinical-case-format.md)
+- [Integration notes](integrations/integration-overview.md)
+- [Configuration management rules](cm/configuration-management.md)

--- a/docs/product/technical-product-description.md
+++ b/docs/product/technical-product-description.md
@@ -1,111 +1,164 @@
 # Technical Product Description — Virtual AI Patient
 
-## 1. Product summary
-Virtual AI Patient is a training platform where a learner (medical student / junior doctor) completes a full clinical workflow in a safe environment:
-1) history taking and communication, 2) diagnostic reasoning, 3) ordering medical tests, 4) diagnosis, 5) treatment plan, 6) debriefing with feedback against a gold standard.
+## 1. Problem statement
 
-The platform provides **dynamic, realistic patient dialogue** and **clinically plausible data** (symptoms, timeline, risk factors, exam findings, and test results).
+Medical students and early-career doctors need repeated practice in clinical
+communication and diagnostic reasoning, but real-patient practice is limited
+and scripted cases do not reproduce the uncertainty of a consultation.
+Instructor-led simulation is valuable, yet it also requires a trained person
+to play the patient and significant educator time to run and review each case.
 
-## 2. Users and primary use cases
-### 2.1 Learner (student / junior doctor)
-- Runs interactive cases end-to-end.
-- Practices structured history taking (HPI, ROS, PMH, FH, SH, meds, allergies).
-- Requests labs/instrumental studies (ECG, imaging, etc.).
-- Submits differential diagnosis, final diagnosis, and management plan.
-- Receives a debrief: missed questions, unnecessary tests, incorrect interpretation, unsafe treatment, and a reference solution.
+Virtual AI Patient explores whether a conversational simulator can provide
+repeatable practice of the full clinical loop: history taking, examination
+decisions, investigation ordering, differential diagnosis, final diagnosis,
+management, and debriefing.
 
-### 2.2 Educator / clinical expert
-- Creates and curates clinical cases and gold standards.
-- Reviews analytics (common mistakes, learning gaps).
-- Adjusts rubrics and acceptable-answer sets.
-- Feedback on results.
+### Market context
+
+Comparable platforms already exist, which validates demand for this type of
+training rather than proving that a feature list is unique. Our
+[expert interviews](../proposal/user-insights.md) indicate that differentiation
+must come from execution quality: a believable patient role, a coherent
+clinical-case system, and an engaging learning loop. Features can be copied;
+the consistency and realism of the experience are harder to reproduce.
+
+## 2. Users and what the prototype demonstrates
+
+### 2.1 Learner (student or junior doctor)
+
+The prototype demonstrates that a learner can:
+
+- run an interactive case from first contact to debrief;
+- practise structured history taking without receiving all information at once;
+- request laboratory and instrumental investigations;
+- submit a ranked differential, final diagnosis, and management plan;
+- receive feedback on missed red flags, unnecessary tests, unsafe decisions,
+  and reasoning bias.
+
+### 2.2 Educator or clinical expert
+
+The prototype demonstrates that an educator can:
+
+- define a case, its ground truth, and an assessment rubric;
+- review a learner's decisions and common mistakes;
+- tune acceptable answers and the feedback shown in the debrief;
+- reuse a case without training a separate simulated-patient actor for every
+  session.
 
 ### 2.3 Technical administrator
-- Collect statistics on tests amount to see the bottleneck .
-- Correct bottlenecks
 
-## 3. Core product requirements (functional)
-### 3.1 Case library
-- A library of cases across multiple nosologies and difficulty levels.
-- Each case has:
-  - patient persona (age/sex/context)
-  - chief complaint + symptoms timeline
-  - history of illness
-  - structured “truth” (ground truth: diagnosis + key features)
-  - expected diagnostics (must-have vs optional)
-  - gold standard interpretation
-  - gold standard management plan (including contraindications)
-  - scoring rubric and feedback text components
+The prototype demonstrates that an administrator can:
 
-### 3.2 Conversational virtual patient
-- Patient responds in a clinically plausible way, reflecting:
-  - partial recall, uncertainty, emotions
-  - different levels of health literacy
-  - progressive revelation (information is not dumped; it appears when asked)
-- Tone styles: neutral, anxious, irritated, distressed, etc.
-- Guardrails:
-  - no real-world medical advice disclaimers to user in training context (content is for simulated training, LLM doesn't leave from the context of training),
-  - avoid generating harmful instructions outside the case scenario.
+- observe session and investigation usage;
+- identify technical bottlenecks and failed interactions;
+- manage access to the prototype and its case content.
 
-### 3.3 Medical tests ordering and results
-- The learner can order labs/instrumental studies from a optional catalog, supported by human.
-- Results should be:
-  - plausible for the clinical picture and timeline,
-  - optionally include uncertainty / borderline results.
+These roles describe evidence produced by the prototype, not commitments for a
+production deployment.
 
-### 3.4 Decision capture (learner outputs)
-The system must allow structured submission of:
-- ordered medical tests
-- differential diagnosis (ranked)
-- final diagnosis (ICD/SNOMED mapping optional for later)
-- treatment plan (medications, dose, non-pharmacological, referral, follow-up)
+## 3. Differentiators
 
-### 3.5 Automated evaluation + debriefing
-Evaluation compares learner decisions to the case gold standard:
-- Diagnosis correctness and reasoning quality
-- Diagnostic plan appropriateness (missing critical tests, ordering unnecessary tests)
-- Treatment plan safety and guideline alignment (at least for the supported conditions)
-- Communication quality (optional v2): empathy, clarity, structure
+### 3.1 LLM patient-role quality
 
-Debriefing must include:
-- what was correct,
-- what was missing and why it matters,
-- what was unsafe/incorrect and potential consequences,
-- reference solution (key findings, recommended tests, diagnosis, treatment).
+The patient should behave like a person, not a searchable case record. Depending
+on the scenario, the role may forget details, hesitate, misunderstand a
+question, withhold information, lie, become anxious or irritated, or present
+while intoxicated. Information is revealed progressively and remains consistent
+with the case truth. The quality target is sustained role immersion and
+believable imperfection, including different levels of health literacy.
 
-### 3.6 Case authoring & adding
-To reach 50+ cases efficiently, the platform needs:
-- a standardized case schema,
-- validation (required fields, consistency checks),
-- ability to import cases in bulk (e.g., JSON/YAML + attachments),
-- versioning and status (draft → reviewed → published).
+### 3.2 Constrained clinical-case system
 
-### 3.7 Integration
-- Authorization and authentication integration with partner platform.
-- APIs for:
-  - launching a case
-  - retrieving progress and scores
-  - exporting learning analytics
+Each case combines narrative data with explicit rules:
 
-## 4. Platform concept (modules)
-- **Telegram-bot**: user stories flow, chat, medical tests ordering, submission forms, debrief view.
-- **Frontend (Flutter)**: chat UI, medical tests ordering UI, submission forms, debrief view.
-- **Backend API (FastAPI)**:
-  - authentication/authorization
-  - case session state
-  - medical tests ordering and result generation
-  - evaluation + scoring
-  - analytics export
-- **Database Interface**:
-  - CRUD-operations
-  - Entities persistence  
-- **AI Interface** (backend module):
-  - prompt templates + tool calls
-  - policy/guardrails layer
-  - OpenAI-compatible provider adapter (token-based)
+- patient persona, complaint, symptom timeline, history, and objective findings;
+- ground-truth diagnosis and clinically important features;
+- compatible investigations and plausible results for the case and timeline;
+- a price or resource cost for each investigation;
+- an investigation budget or other limit that makes unnecessary testing matter;
+- required, optional, and unsafe actions;
+- a gold-standard interpretation, management plan, and scoring rubric.
 
-## 5. Scope boundaries (explicit)
-- Not a real medical device; not for real patient advice.
-- Initial versions focus on a limited set of conditions with high educational value and well-defined gold standards.
-- Results are *clinically plausible simulations*, not patient-specific evidence.
+This structure allows the simulator to assess more than diagnosis accuracy. It
+can also detect failure to escalate a critical presentation and confirmation
+bias, where evidence is forced to fit an early diagnosis.
 
+### 3.3 Game mechanics
+
+The training loop is designed as a diagnostic game rather than a sequence of
+forms. The learner uncovers the real symptom pattern through conversation,
+spends a limited investigation budget, makes decisions under uncertainty, and
+sees the consequences in a debrief. The intended feel is a responsible
+House, M.D.-style clinical puzzle: curiosity and discovery support learning,
+while the scoring model still rewards safety and sound reasoning.
+
+## 4. Prototype capabilities
+
+### 4.1 Case library and authoring
+
+The prototype supports a small, reviewed library across selected conditions and
+difficulty levels. A standard case schema, validation rules, draft/reviewed
+status, and JSON or YAML import keep case content reproducible. Scaling the
+library is a research and content-governance problem, not only a generation
+task.
+
+### 4.2 Conversational virtual patient
+
+The patient responds with clinically plausible language, tone, partial recall,
+and progressive disclosure. Prompting and guardrails keep the model inside the
+simulated role and prevent unsupported changes to the case truth.
+
+### 4.3 Medical investigations
+
+The learner orders tests from the catalog allowed by the active case. Results
+must be compatible with the clinical picture and timeline and may include
+borderline values or uncertainty when the case defines them. Cost and budget
+signals make investigation choices part of the exercise.
+
+### 4.4 Decision capture and debriefing
+
+The prototype records ordered tests, a ranked differential, the final diagnosis,
+and a management plan. Evaluation compares those decisions with the case rubric
+and reports:
+
+- correct findings and decisions;
+- missed questions, red flags, and critical escalation;
+- unnecessary or incompatible investigations;
+- unsafe treatment choices and likely consequences;
+- signs of confirmation bias;
+- a reference reasoning path and management plan.
+
+## 5. Platform concept
+
+- **Flutter frontend:** case selection, chat, investigation ordering, decision
+  submission, and debrief views.
+- **Telegram bot:** an alternative conversational interface for prototype
+  sessions.
+- **FastAPI backend:** authentication, session state, case access, investigation
+  results, scoring, and analytics export.
+- **Database layer:** persistence for cases, sessions, decisions, and revisions.
+- **AI interface:** patient-role prompts, tool calls, guardrails, and an
+  OpenAI-compatible provider adapter.
+
+Interfaces are designed so that later integration can be evaluated, but the
+prototype does not guarantee integration with a particular customer platform.
+
+## 6. Scope boundaries
+
+This work is a validated prototype and startup proposal within a software
+engineering course.
+
+Out of scope:
+
+- a business model or pricing strategy;
+- financial projections or valuation;
+- a go-to-market plan;
+- service-level agreements or production support commitments;
+- a guaranteed pilot, deployment date, or customer-specific integration;
+- use as a medical device or for real-patient advice.
+
+Business modelling without reliable market data would be speculation and falls
+outside the software-engineering course scope. The prototype instead provides
+technical evidence for the core learning experience. It initially covers a
+limited set of educational cases with reviewed gold standards; all outputs are
+clinical simulations, not patient-specific evidence.

--- a/docs/proposal/index.md
+++ b/docs/proposal/index.md
@@ -1,0 +1,13 @@
+---
+title: Proposal
+nav_order: 2
+has_children: true
+---
+
+# Proposal
+
+This section contains the evidence and working documents behind the startup
+proposal for Virtual AI Patient.
+
+- [User insights](user-insights.md) records interviews and corridor-test
+  findings in a traceable format.

--- a/docs/proposal/user-insights.md
+++ b/docs/proposal/user-insights.md
@@ -1,0 +1,91 @@
+---
+title: User insights
+parent: Proposal
+nav_order: 3
+---
+
+# User Insights
+
+This page is the running **L2 User Insight artifact** defined by
+[Configuration Management](../cm/configuration-management.md). It records
+interviews, expert sessions, and corridor tests in a consistent format so that
+proposal claims can be traced to evidence and linked hypotheses.
+
+## Entry template
+
+Copy this block for every new entry. Keep key insights to five items or fewer.
+
+### YYYY-MM-DD — P-XX
+
+- **Date:** YYYY-MM-DD
+- **Participant:** P-XX
+- **Method:** interview | corridor test | expert session
+- **Context:** One line describing what the participant was shown or asked.
+- **Key insights:**
+  - Insight stated as an observation, not an unsupported conclusion.
+- **Linked hypothesis:** H1 | H2 | H3 | none
+- **Follow-up issues:** GitHub issue links, or none yet.
+
+## Anonymisation guideline
+
+An entry is acceptable only when all of the following are true:
+
+- the participant is identified by an anonymous handle such as P-01;
+- personal names and institution names are not recorded;
+- a clinical specialty and a location are never recorded together;
+- quotations and context do not contain details that can re-identify the
+  participant;
+- follow-up issues link to project work, not to private interview material.
+
+A reviewer should request a change before merging any entry that breaks one of
+these rules.
+
+## Entries
+
+### 2026-07-22 — P-01
+
+- **Date:** 2026-07-22
+- **Participant:** P-01
+- **Method:** expert session
+- **Context:** Retrospective notes from the first expert interview about training
+  value, clinical reasoning errors, and realistic patient simulation.
+- **Key insights:**
+  - The expert estimated that a comparable product could have substantial
+    commercial value (about 20 million; currency was not recorded), but this is
+    directional evidence rather than a financial projection.
+  - A simulator could save educator time and reduce repeated training of people
+    who act as patients in scenario-based teaching.
+  - Two serious learner errors are missing a presentation that needs immediate
+    escalation and forcing symptoms to fit an early diagnosis.
+  - Cases should distinguish subjective patient-reported information from
+    objective findings and support a workflow that can include tests, referrals,
+    and delayed diagnosis.
+  - The patient role should allow emotion, incomplete or false answers,
+    confusion, and intoxication instead of modelling an ideal patient.
+- **Linked hypothesis:** H1, H3
+- **Follow-up issues:** [#81](https://github.com/virtual-ai-patient/platform/issues/81),
+  [#85](https://github.com/virtual-ai-patient/platform/issues/85),
+  [#88](https://github.com/virtual-ai-patient/platform/issues/88)
+
+### 2026-07-22 — P-02
+
+- **Date:** 2026-07-22
+- **Participant:** P-02
+- **Method:** expert session
+- **Context:** Retrospective notes from the second expert interview about market
+  context and the qualities that should differentiate the prototype.
+- **Key insights:**
+  - Similar products already exist, which supports demand for the concept.
+  - Individual features are easy to copy; differentiation should come from the
+    quality and consistency of the whole learning experience.
+  - Clinical cases need explicit investigation prices, test-to-case
+    compatibility, and other constraints that can be assessed.
+  - Patient-role immersion depends on believable forgetting, lying, hesitation,
+    emotion, and delayed disclosure.
+  - The simulator should feel like a diagnostic game, using scarce tests and
+    symptom discovery to create a responsible House, M.D.-style puzzle.
+- **Linked hypothesis:** H1, H2, H3
+- **Follow-up issues:** [#81](https://github.com/virtual-ai-patient/platform/issues/81),
+  [#85](https://github.com/virtual-ai-patient/platform/issues/85),
+  [#88](https://github.com/virtual-ai-patient/platform/issues/88),
+  [#89](https://github.com/virtual-ai-patient/platform/issues/89)


### PR DESCRIPTION
## Summary

- reframe the technical product description around the validated-prototype proposal
- capture both expert interviews in a structured L2 user-insight log
- add enforceable anonymisation rules and a reusable entry template
- register the Proposal section in Jekyll navigation and refresh the documentation index

## Validation

- reviewed the rendered Markdown for the technical description and interview log
- verified relative links on the branch
- confirmed the branch is mergeable and contains only the four documentation files

Closes #81
Closes #90