### PR TITLE
cm: introduce rev1/rev2 structure around project goal pivot

### DIFF
--- a/docs/cm/configuration-management-rev1.md
+++ b/docs/cm/configuration-management-rev1.md
@@ -1,0 +1,70 @@
+
+# Configuration Management — Revision 1 (pre-pivot)
+
+> **Historical document.** This revision was written when the project was
+> delivering a product to an industry partner. The engagement did not progress
+> to a signed agreement. In March 2026 the goal shifted to a startup proposal;
+> see [Revision 2](configuration-management-rev2.md).
+
+# Configuration Management & Traceability Policy — Virtual AI Patient
+
+## 1. The Hierarchy of Artifacts
+
+To maintain a strict "Chain of Truth," every artifact in the repository follows a specific hierarchy. No development task may exist without a reference to a higher-level requirement revision.
+
+1. **Level 1: Product Overview (`/docs/product/technical-product-description.md`)** – High-level vision and business boundaries.
+2. **Level 2: Quality Attributes (`/docs/qa/qa-rev(N).md`)** – Technical benchmarks and performance metrics.
+3. **Level 3: Architecture & Design (`/docs/architecture/`)** – System diagrams and technical specifications.
+4. **Level 4: GitHub Epics** – Business value units containing User Stories and Dependencies.
+5. **Level 5: GitHub Tasks** – Atomic implementation units with specific Acceptance Criteria (AC).
+6. **Level 6: Git Branches & Commits** – The physical code implementation.
+
+## 2. Traceability & Linkage Rules
+
+Every artifact must be bi-directionally linked using the following "Thread of Integrity."
+
+### 2.1. Documentation as the Source of Truth
+
+All high-level documentation is hosted at: `https://virtual-ai-patient.github.io/platform`.
+
+* **Epics** must include a **"Documentation Reference"** section in their description, linking to the specific `qa-rev(N).md` or Architecture page they implement.
+* **Example:** `Ref: [QA-Rev3 - Latency Requirements](https://virtual-ai-patient.github.io/platform/qa/qa-rev3)`.
+
+### 2.2. The Implementation Chain (Code to QA)
+
+To ensure every line of code serves a requirement, the following mapping is mandatory:
+
+| Artifact | Linkage Requirement | Key Metadata to Include |
+| --- | --- | --- |
+| **GitHub Epic** | URL to `technical-product-description.md` or `qa-rev(N).md` | User Story, Dependencies, Epic-level AC. |
+| **GitHub Task** | Parent Epic ID (#Number) | Technical AC, link to Architecture doc if applicable. |
+| **Git Branch** | Task ID in branch name (e.g., `feature/#123-ai-tone`) | Link to the Task being solved. |
+| **Pull Request** | Task ID and Link to updated Docs | "Closes #123"; confirms no drift from `qa-rev(N).md`. |
+
+## 3. Quality Attributes (QA) Revision Policy
+
+Non-functional requirements are managed in the `/docs/qa/` directory.
+
+* **Naming:** Files are named `qa-rev(N).md` (e.g., `qa-rev1.md`).
+* **Changelog:** Every revision must conclude with a summary of changes, the reason for the change, and a link to the `action-points.md` from the meeting that triggered it.
+* **Acceptance Criteria (AC) Alignment:** The AC in a GitHub Task must be a direct derivative of the current `qa-rev(N).md`. If the QA rev says "AI response $\le$ 5s", the Task AC must explicitly state: *"Verify response time is $\le$ 5s per qa-rev(N)"*.
+
+
+## 4. Traceability Workflow: The "Impact Ripple"
+
+When a change occurs, the following "ripple" must be executed to prevent documentation-code drift:
+
+1. **Trigger:** A client meeting results in an `action-point.md` to change the Evaluation scoring logic.
+2. **Doc Update:** The Analyst creates a new `qa-rev(N+1).md` at `https://virtual-ai-patient.github.io/platform/qa/qa-rev(N+1)`.
+3. **Epic Revision:** The corresponding GitHub Epic is updated. The "Documentation Reference" link is changed to the new URL.
+4. **Task Validation:** Existing Tasks under that Epic are reviewed. If their Acceptance Criteria contradict the new QA revision, they are put on "Hold" and updated.
+5. **Code Alignment:** Developers update the branch implementation to meet the new AC defined by the revised QA document.
+
+
+## 5. Definition of Done (DoD)
+
+A Task or Epic is only considered "Done" if:
+
+* [ ] The code passes all technical Acceptance Criteria.
+* [ ] The implementation is verified against the linked `qa-rev(N).md` metrics.
+* [ ] The documentation on `https://virtual-ai-patient.github.io/platform` reflects the current state of the feature.

--- a/docs/cm/configuration-management-rev2.md
+++ b/docs/cm/configuration-management-rev2.md
@@ -1,0 +1,155 @@
+# Configuration Management — Revision 2 (post-pivot: startup proposal)
+
+## 1. Artifact Hierarchy
+
+Every artifact in the repository traces back to the project goal through a five-level chain. No GitHub Issue may exist without a reference to a Level 2 or Level 3 artifact.
+
+```text
+L1  Goal statement
+    docs/product/technical-product-description.md
+
+L2  Evidence artifacts
+    docs/proposal/user-insights.md
+    Expert meeting notes, interview summaries, corridor-test findings
+
+L3  Hypothesis + validation plan
+    docs/proposal/hypotheses.md
+    Value Proposition Canvas
+
+L4  GitHub Issues
+    Research tasks and prototype tasks with Acceptance Criteria
+
+L5  Prototype version + validation result
+    Git commit tagged P1-tag / P2-tag / P3-tag
+    Validation finding recorded in L2 artifact
+```
+
+### What each level means
+
+| Level | Owner | Changes when… |
+|:---|:---|:---|
+| L1 | Alina / Karim | Project goal is redefined |
+| L2 | Alina | A user interview, expert session, or corridor test is conducted |
+| L3 | Karim | A hypothesis is opened, updated, confirmed, or refuted |
+| L4 | Karim | A hypothesis needs new work to advance |
+| L5 | Ilnar / Timur / Aizat | A prototype iteration is ready for validation |
+
+---
+
+## 2. User Insight — first-class artifact type
+
+A **User Insight** is any finding from a user interview, expert session, or corridor test that advances or challenges a hypothesis. It is recorded in `docs/proposal/user-insights.md` using the template below immediately after the session.
+
+### Template
+
+```markdown
+### YYYY-MM-DD — P-XX
+
+- **Date:** YYYY-MM-DD
+- **Participant:** P-XX  (anonymous handle — never a name)
+- **Method:** interview | corridor test | expert session
+- **Context:** One line — what the participant was shown or asked.
+- **Key insights:**
+  - Observation stated as a finding, not an unsupported conclusion. (≤ 5 items)
+- **Linked hypothesis:** H1 | H2 | H3 | none
+- **Follow-up issues:** #NNN, or "none yet"
+```
+
+### Anonymisation rules
+
+An entry is acceptable only when **all** of the following hold:
+
+- Participant identified by handle only (P-01, P-02 …).
+- No personal names, institution names, or identifying role+location combinations.
+- No quotation contains re-identifying detail.
+- Follow-up issues link to project work, not to private interview material.
+
+A reviewer must request a change before merging any entry that breaks one of these rules.
+
+---
+
+## 3. Traceability rules
+
+Every artifact must satisfy the linkage requirement for its level.
+
+| Artifact | Must reference | Key fields |
+|:---|:---|:---|
+| **L3 hypothesis** | L1 goal statement | Hypothesis statement, owner, validation method, status |
+| **GitHub Issue** | L2 insight entry or L3 hypothesis | AC tied to the hypothesis; linked issue numbers |
+| **Git branch** | Issue number in branch name (`feature/NNN-short-name`) | — |
+| **Pull Request** | `Closes #NNN`; link to updated doc if doc changed | Confirms no drift from current QA revision |
+| **Prototype tag** (L5) | L3 hypothesis being tested | Validation finding recorded in L2 before tag is created |
+
+### Documentation as source of truth
+
+All practice area documents are published at `https://virtual-ai-patient.github.io/platform`. A claim in a GitHub Issue must link to the published URL of the L2 or L3 artifact it derives from — not to a file path.
+
+Example: `Ref: [QA-rev3 — Reproducibility](https://virtual-ai-patient.github.io/platform/qa/qa-rev3#6-reproducibility-qa-repro-new)`
+
+---
+
+## 4. Change trigger — the "Impact Ripple"
+
+Changes propagate **downward** from the level where the change originates. A change at L2 (new insight) may require updates at L3 (hypothesis refined), L4 (new issues), and L5 (prototype iteration replanned). A change at L4 (issue closed) propagates upward only if it closes or refutes a hypothesis.
+
+### Trigger: new user or expert insight (most common)
+
+1. Alina conducts a session and records a User Insight entry in `docs/proposal/user-insights.md`.
+2. If the insight changes what a hypothesis claims or how it is validated, Karim updates `docs/proposal/hypotheses.md` (status, validation method, or linked evidence).
+3. If the updated hypothesis requires new or changed work, Karim opens or updates GitHub Issues at L4.
+4. Team implements; Ilnar / Timur / Aizat update the prototype.
+5. When the iteration is ready for validation, the commit is tagged (P1-tag / P2-tag / P3-tag) and the validation finding is recorded as a new L2 entry.
+
+### Trigger: hypothesis refuted
+
+A refuted hypothesis is **not silently dropped**. Karim:
+
+1. Updates `docs/proposal/hypotheses.md` — status → *refuted*, evidence link filled.
+2. Opens a retrospective issue: what the finding means and whether a new hypothesis is warranted.
+3. Notifies the team at the next Monday planning.
+
+### Trigger: QA revision
+
+If QA attributes change (new `qa-rev(N).md`), Karim reviews open GitHub Issues for AC drift. Any Issue whose AC contradicts the new revision is put on hold and updated before work resumes.
+
+---
+
+## 5. QA revision policy
+
+Non-functional requirements and validation criteria are managed under `/docs/qa/`.
+
+- **Naming:** `qa-rev1.md`, `qa-rev2.md`, `qa-rev3.md` … — never overwrite a previous revision.
+- **Current revision:** `qa-rev3.md` (prototype + handoff scope, post-pivot).
+- **Changelog:** Every revision ends with a changelog table: date, author, trigger, changes made.
+- **AC alignment:** The AC in a GitHub Issue must cite the specific QA attribute it satisfies. Example: *"Verified per QA-REPRO-01: `docker compose up` reaches working demo."*
+
+---
+
+## 6. Definition of Done
+
+### Task (L4 → L5)
+
+A GitHub Issue is **Done** only when:
+
+- [ ] The artifact or code change described in the AC is complete and merged.
+- [ ] The linked hypothesis has advanced: new evidence recorded, hypothesis status updated, or — if refuted — a retrospective issue opened.
+- [ ] Any updated documentation is live on `https://virtual-ai-patient.github.io/platform`.
+
+"Tests pass" or "PR merged" alone is **not** sufficient to close an issue.
+
+### Prototype iteration (L5)
+
+A prototype iteration (P1 / P2 / P3) is **Done** only when:
+
+- [ ] The hypothesis it targets is explicitly confirmed or refuted.
+- [ ] The validation finding is recorded as a User Insight entry (L2).
+- [ ] The commit used for the validation session is tagged (`P1-tag`, `P2-tag`, or `P3-tag`).
+- [ ] `docs/proposal/hypotheses.md` shows the updated status.
+
+---
+
+## Changelog
+
+| Date | Author | Trigger | Changes |
+|:---|:---|:---|:---|
+| March 2026 | Karim Abdulkin | Pivot to startup proposal goal; industry partner engagement did not progress | Full rewrite. Replaced six-level product-delivery hierarchy with five-level hypothesis-driven hierarchy (L1 goal → L2 insights → L3 hypotheses → L4 issues → L5 prototype versions). Added User Insight as a first-class artifact type with template and anonymisation rules. Changed Impact Ripple trigger from "customer meeting" to "user or expert session". Updated DoD to require hypothesis advancement, not only code merge. |

--- a/docs/cm/configuration-management.md
+++ b/docs/cm/configuration-management.md
@@ -1,63 +1,25 @@
+# Configuration Management — History
 
-# Configuration Management & Traceability Policy — Virtual AI Patient
+This document tracks the evolution of the CM & Traceability Policy.
+Two revisions exist because the project goal changed in early March 2026.
 
-## 1. The Hierarchy of Artifacts
+| Revision | Goal | Date | Document |
+|:---|:---|:---|:---|
+| **Rev 1** | Deliver a product to an industry partner (Third Opinion) | January 2026 | [configuration-management-rev1.md](configuration-management-rev1.md) |
+| **Rev 2** | Deliver a startup proposal backed by a validated prototype | March 2026 | [configuration-management-rev2.md](configuration-management-rev2.md) |
 
-To maintain a strict "Chain of Truth," every artifact in the repository follows a specific hierarchy. No development task may exist without a reference to a higher-level requirement revision.
+## What changed and why
 
-1. **Level 1: Product Overview (`/docs/product/technical-product-description.md`)** – High-level vision and business boundaries.
-2. **Level 2: Quality Attributes (`/docs/qa/qa-rev(N).md`)** – Technical benchmarks and performance metrics.
-3. **Level 3: Architecture & Design (`/docs/architecture/`)** – System diagrams and technical specifications.
-4. **Level 4: GitHub Epics** – Business value units containing User Stories and Dependencies.
-5. **Level 5: GitHub Tasks** – Atomic implementation units with specific Acceptance Criteria (AC).
-6. **Level 6: Git Branches & Commits** – The physical code implementation.
+Rev 1 defined a six-level artifact chain tied to customer requirements:
+product description → QA → architecture → epics → tasks → commits.
+The change trigger was a customer meeting.
 
-## 2. Traceability & Linkage Rules
+When the industry partner engagement did not progress and the goal shifted
+to a startup proposal, the artifact chain needed to reflect a different
+source of truth: user and expert insights drive hypotheses, hypotheses
+drive issues, issues drive prototype iterations. Rev 2 replaces the
+six-level chain with a five-level hypothesis-driven hierarchy and adds
+**User Insight** as a first-class artifact type with a fixed template
+and anonymisation rules.
 
-Every artifact must be bi-directionally linked using the following "Thread of Integrity."
-
-### 2.1. Documentation as the Source of Truth
-
-All high-level documentation is hosted at: `https://virtual-ai-patient.github.io/platform`.
-
-* **Epics** must include a **"Documentation Reference"** section in their description, linking to the specific `qa-rev(N).md` or Architecture page they implement.
-* **Example:** `Ref: [QA-Rev3 - Latency Requirements](https://virtual-ai-patient.github.io/platform/qa/qa-rev3)`.
-
-### 2.2. The Implementation Chain (Code to QA)
-
-To ensure every line of code serves a requirement, the following mapping is mandatory:
-
-| Artifact | Linkage Requirement | Key Metadata to Include |
-| --- | --- | --- |
-| **GitHub Epic** | URL to `technical-product-description.md` or `qa-rev(N).md` | User Story, Dependencies, Epic-level AC. |
-| **GitHub Task** | Parent Epic ID (#Number) | Technical AC, link to Architecture doc if applicable. |
-| **Git Branch** | Task ID in branch name (e.g., `feature/#123-ai-tone`) | Link to the Task being solved. |
-| **Pull Request** | Task ID and Link to updated Docs | "Closes #123"; confirms no drift from `qa-rev(N).md`. |
-
-## 3. Quality Attributes (QA) Revision Policy
-
-Non-functional requirements are managed in the `/docs/qa/` directory.
-
-* **Naming:** Files are named `qa-rev(N).md` (e.g., `qa-rev1.md`).
-* **Changelog:** Every revision must conclude with a summary of changes, the reason for the change, and a link to the `action-points.md` from the meeting that triggered it.
-* **Acceptance Criteria (AC) Alignment:** The AC in a GitHub Task must be a direct derivative of the current `qa-rev(N).md`. If the QA rev says "AI response $\le$ 5s", the Task AC must explicitly state: *"Verify response time is $\le$ 5s per qa-rev(N)"*.
-
-
-## 4. Traceability Workflow: The "Impact Ripple"
-
-When a change occurs, the following "ripple" must be executed to prevent documentation-code drift:
-
-1. **Trigger:** A client meeting results in an `action-point.md` to change the Evaluation scoring logic.
-2. **Doc Update:** The Analyst creates a new `qa-rev(N+1).md` at `https://virtual-ai-patient.github.io/platform/qa/qa-rev(N+1)`.
-3. **Epic Revision:** The corresponding GitHub Epic is updated. The "Documentation Reference" link is changed to the new URL.
-4. **Task Validation:** Existing Tasks under that Epic are reviewed. If their Acceptance Criteria contradict the new QA revision, they are put on "Hold" and updated.
-5. **Code Alignment:** Developers update the branch implementation to meet the new AC defined by the revised QA document.
-
-
-## 5. Definition of Done (DoD)
-
-A Task or Epic is only considered "Done" if:
-
-* [ ] The code passes all technical Acceptance Criteria.
-* [ ] The implementation is verified against the linked `qa-rev(N).md` metrics.
-* [ ] The documentation on `https://virtual-ai-patient.github.io/platform` reflects the current state of the feature.
+The current active revision is **[Revision 2](configuration-management-rev2.md)**.


### PR DESCRIPTION
Introduces rev1/rev2 structure for Configuration Management.

 Rev 1 preserves the original six-level product-delivery hierarchy with a historical banner. Rev 2 replaces it with an L1–L5 hypothesis-driven hierarchy (goal → user insights → hypotheses → GitHub issues → prototype versions), defines the User Insight as a first-class L2 artifact with anonymisation rules, and reframes the DoD and
 Impact Ripple around hypothesis advancement.

- [x] Written from March 2026 post-pivot perspective
- [x] Rev 1 preserved with historical banner; not modified
- [x] User Insight template and anonymisation rules included
- [x] DoD requires hypothesis to be advanced, not just tasks completed

Closes #86