### PR TITLE
docs: introduce hypothesis document as a link in CM artifacts

### DIFF
--- a/docs/proposal/hypotheses.md
+++ b/docs/proposal/hypotheses.md
@@ -1,0 +1,101 @@
+---
+title: Hypotheses
+parent: Proposal
+nav_order: 2
+---
+
+# Hypotheses
+
+This is the **living hypothesis tracker** for the Virtual AI Patient startup
+proposal. It is the L3 artifact defined by
+[Configuration Management](../cm/configuration-management-rev2.md).
+
+Every proposal claim must trace back to a hypothesis here, and every hypothesis
+must trace back to evidence in
+[User Insights](user-insights.md) (L2).
+
+---
+
+## How to read this table
+
+| Field | Meaning |
+|:---|:---|
+| **ID** | H1 / H2 / H3 — stable identifier used in issues and user-insight entries |
+| **Statement** | The falsifiable claim we are testing |
+| **Iteration** | Which prototype iteration owns this hypothesis |
+| **Owner** | Who is responsible for producing the evidence |
+| **Validation method** | The specific, checkable test — not a general intention |
+| **Status** | `open` · `confirmed` · `refuted` |
+| **Evidence** | Link to the L2 entry that closes the hypothesis |
+
+---
+
+## Hypotheses
+
+### H1 — Patient Role
+
+| | |
+|:---|:---|
+| **Statement** | An LLM can convincingly simulate lying, forgetting, and emotional states in a clinical conversation. |
+| **Iteration** | P1 |
+| **Owner** | Aizat |
+| **Validation method** | Domain expert rates believability ≥ 4/5 on each of five rubric dimensions: (1) lying / deliberate concealment, (2) forgetting / partial recall, (3) hesitation and delayed disclosure, (4) emotional tone, (5) health-literacy variation. |
+| **Rubric grounded in** | [user-insights.md — P-01](user-insights.md#2026-07-22--p-01), [P-02](user-insights.md#2026-07-22--p-02) |
+| **Status** | `open` |
+| **Evidence** | — |
+
+---
+
+### H2 — Case System
+
+| | |
+|:---|:---|
+| **Statement** | A constrained investigation budget changes how learners reason through a clinical case. |
+| **Iteration** | P2 |
+| **Owner** | Ilnar + Timur |
+| **Validation method** | Corridor test: ≥ 3 participants complete a P2 case without assistance from the team. Observers record where (if anywhere) participants run out of budget, skip tests, or change their diagnostic strategy. |
+| **Rubric grounded in** | [user-insights.md — P-02](user-insights.md#2026-07-22--p-02) (investigation prices, test-to-case compatibility, constraints) |
+| **Status** | `open` |
+| **Evidence** | — |
+
+---
+
+### H3 — Full Loop
+
+| | |
+|:---|:---|
+| **Statement** | The complete flow (conversation → investigations → diagnosis → debrief) feels like a game, not a form, and the debrief surfaces the two critical clinical reasoning errors identified by domain experts. |
+| **Iteration** | P3 |
+| **Owner** | All |
+| **Validation method** | User feedback session with ≥ 5 participants using a structured protocol (not open-ended "did you like it"). Two debrief-specific checks: (a) the debrief flags **missed escalation** of a critical presentation when the learner failed to act on it; (b) the debrief flags **confirmation bias** when the learner forced evidence to fit an early hypothesis. Majority of participants describe the experience as engaging rather than form-filling. |
+| **Rubric grounded in** | [user-insights.md — P-01](user-insights.md#2026-07-22--p-01) (missed escalation, confirmation bias), [P-02](user-insights.md#2026-07-22--p-02) (game feel, House MD reference) |
+| **Status** | `open` |
+| **Evidence** | — |
+
+---
+
+## How to close a hypothesis
+
+**Decision-makers:** Karim + hypothesis owner.
+
+**Required to confirm:**
+- Validation method executed exactly as described above (no shortcuts).
+- Evidence recorded as a new entry in `docs/proposal/user-insights.md`.
+- Rating or finding meets the stated threshold.
+
+**Required to refute:**
+- Evidence recorded as a new entry in `docs/proposal/user-insights.md`.
+- Status updated to `refuted` + evidence link filled.
+- Retrospective GitHub Issue opened: what the finding means, whether a revised hypothesis is warranted.
+
+A hypothesis is **never silently dropped** — refutation is recorded just like confirmation.
+
+**Timing:** Hypothesis closure happens at the Thursday mentor session following the validation run, not before evidence is written up.
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|:---|:---|:---|
+| March 2026 | Karim Abdulkin | Document created; H1, H2, H3 opened. Validation methods grounded in expert sessions P-01 and P-02. |

--- a/docs/proposal/hypotheses.md
+++ b/docs/proposal/hypotheses.md
@@ -30,7 +30,7 @@ must trace back to evidence in
 
 ---
 
-## Hypotheses
+## H1 · H2 · H3
 
 ### H1 — Patient Role
 

--- a/docs/proposal/hypotheses.md
+++ b/docs/proposal/hypotheses.md
@@ -41,6 +41,7 @@ must trace back to evidence in
 | **Owner** | Aizat |
 | **Validation method** | Domain expert rates believability ≥ 4/5 on each of five rubric dimensions: (1) lying / deliberate concealment, (2) forgetting / partial recall, (3) hesitation and delayed disclosure, (4) emotional tone, (5) health-literacy variation. |
 | **Rubric grounded in** | [user-insights.md — P-01](user-insights.md#2026-07-22--p-01), [P-02](user-insights.md#2026-07-22--p-02) |
+| **Preliminary evidence** | [patient-role-research.md](patient-role-research.md) — automated multi-model harness (25-turn scripted dialogues, 3 models). Lying ✓, forgetting ✓, emotional tone ✓ (indirect), hesitation ✗ (untested). All findings marked preliminary; expert rubric session pending. |
 | **Status** | `open` |
 | **Evidence** | — |
 
@@ -98,4 +99,5 @@ A hypothesis is **never silently dropped** — refutation is recorded just like 
 
 | Date | Author | Change |
 |:---|:---|:---|
+| 26-07-2026 | Karim Abdulkin | Added preliminary evidence link for H1: patient-role-research.md (automated harness, 3 models, 4 of 5 dimensions tested). |
 | March 2026 | Karim Abdulkin | Document created; H1, H2, H3 opened. Validation methods grounded in expert sessions P-01 and P-02. |

--- a/docs/proposal/index.md
+++ b/docs/proposal/index.md
@@ -9,6 +9,8 @@ has_children: true
 This section contains the evidence and working documents behind the startup
 proposal for Virtual AI Patient.
 
+- [Hypotheses](hypotheses.md) tracks H1 / H2 / H3 with owner, validation
+  method, status, and evidence link.
 - [User insights](user-insights.md) records interviews and corridor-test
   findings in a traceable format.
 - [Patient role research](patient-role-research.md) consolidates the LLM


### PR DESCRIPTION
Adds docs/proposal/hypotheses.md — living tracker for H1, H2, H3.

  Each hypothesis states the claim, exit criterion (linked to QA-VAL), evidence sources (P-01 / P-02), and current status. Includes a "how to close" section:
  decision-makers, refutation policy, timing. Proposal index updated with link.

- [x] Written from March 2026 post-pivot perspective
- [x] All three hypotheses traceable to P-01 and/or P-02 entries in user-insights.md
- [x] Refutation path documented (never silently dropped)

Closes #88