### PR TITLE
Add analytics export UI and fix case-card Evaluation display

### DIFF
--- a/frontend/lib/app/app.dart
+++ b/frontend/lib/app/app.dart
@@ -3,6 +3,7 @@ import 'package:frontend/app/app_route_observer.dart';
 import 'package:frontend/app/app_session_router.dart';
 import 'package:frontend/common/theme/app_theme.dart';
 import 'package:frontend/domains/admin/admin_repository.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/auth/auth_repository.dart';
 import 'package:frontend/domains/cases/case_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
@@ -23,6 +24,7 @@ class _VirtualAiPatientAppState extends State<VirtualAiPatientApp> {
   late final SessionRepository _sessionRepository;
   late final EvaluationRepository _evaluationRepository;
   late final CommunicationRepository _communicationRepository;
+  late final ExportRepository _exportRepository;
   Widget? _home;
 
   @override
@@ -45,6 +47,9 @@ class _VirtualAiPatientAppState extends State<VirtualAiPatientApp> {
     _communicationRepository = CommunicationRepository(
       openapi: _authRepository.openapiClient,
     );
+    _exportRepository = ExportRepository(
+      openapi: _authRepository.openapiClient,
+    );
     _bootstrap();
   }
 
@@ -61,6 +66,7 @@ class _VirtualAiPatientAppState extends State<VirtualAiPatientApp> {
               sessionRepository: _sessionRepository,
               evaluationRepository: _evaluationRepository,
               communicationRepository: _communicationRepository,
+              exportRepository: _exportRepository,
               adminRepository: _adminRepository,
             )
           : AppSessionRouter.homeForSession(
@@ -70,6 +76,7 @@ class _VirtualAiPatientAppState extends State<VirtualAiPatientApp> {
               sessionRepository: _sessionRepository,
               evaluationRepository: _evaluationRepository,
               communicationRepository: _communicationRepository,
+              exportRepository: _exportRepository,
               adminRepository: _adminRepository,
             );
     });

--- a/frontend/lib/app/app_session_router.dart
+++ b/frontend/lib/app/app_session_router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/domains/admin/admin_repository.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/auth/auth_repository.dart';
 import 'package:frontend/domains/cases/case_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
@@ -19,6 +20,7 @@ class AppSessionRouter {
     required SessionRepositoryContract sessionRepository,
     required EvaluationRepositoryContract evaluationRepository,
     required CommunicationRepositoryContract communicationRepository,
+    required ExportRepositoryContract exportRepository,
     AdminRepositoryContract? adminRepository,
   }) {
     return LoginScreen(
@@ -27,6 +29,7 @@ class AppSessionRouter {
       sessionRepository: sessionRepository,
       evaluationRepository: evaluationRepository,
       communicationRepository: communicationRepository,
+      exportRepository: exportRepository,
       adminRepository: adminRepository,
     );
   }
@@ -38,6 +41,7 @@ class AppSessionRouter {
     required SessionRepositoryContract sessionRepository,
     required EvaluationRepositoryContract evaluationRepository,
     required CommunicationRepositoryContract communicationRepository,
+    required ExportRepositoryContract exportRepository,
     AdminRepositoryContract? adminRepository,
   }) {
     LoginScreen createLoginScreen() => loginScreen(
@@ -46,6 +50,7 @@ class AppSessionRouter {
       sessionRepository: sessionRepository,
       evaluationRepository: evaluationRepository,
       communicationRepository: communicationRepository,
+      exportRepository: exportRepository,
       adminRepository: adminRepository,
     );
     if (session.user.role == 'admin' && adminRepository != null) {
@@ -53,6 +58,7 @@ class AppSessionRouter {
         session: session,
         adminRepository: adminRepository,
         authRepository: authRepository,
+        exportRepository: exportRepository,
         buildLoginPage: createLoginScreen,
       );
     }
@@ -64,6 +70,7 @@ class AppSessionRouter {
       communicationRepository: communicationRepository,
       authRepository: authRepository,
       adminRepository: adminRepository,
+      exportRepository: exportRepository,
       buildLoginPage: createLoginScreen,
     );
   }

--- a/frontend/lib/common/browser_file_download.dart
+++ b/frontend/lib/common/browser_file_download.dart
@@ -1,0 +1,15 @@
+import 'dart:typed_data';
+
+import 'package:frontend/common/browser_file_download_stub.dart'
+    if (dart.library.html) 'package:frontend/common/browser_file_download_web.dart'
+    as impl;
+
+typedef BrowserFileSaver =
+    void Function({
+      required Uint8List bytes,
+      required String filename,
+      required String mimeType,
+    });
+
+/// Default saver — Blob download on web; throws on other platforms.
+BrowserFileSaver saveBrowserFile = impl.saveBrowserFile;

--- a/frontend/lib/common/browser_file_download_stub.dart
+++ b/frontend/lib/common/browser_file_download_stub.dart
@@ -1,0 +1,13 @@
+import 'dart:typed_data';
+
+/// Non-web fallback — tests inject their own [saveBrowserFile] override.
+void saveBrowserFile({
+  required Uint8List bytes,
+  required String filename,
+  required String mimeType,
+}) {
+  throw UnsupportedError(
+    'Browser file download is only available on Flutter web. '
+    'Inject a saveBrowserFile override in tests.',
+  );
+}

--- a/frontend/lib/common/browser_file_download_web.dart
+++ b/frontend/lib/common/browser_file_download_web.dart
@@ -1,0 +1,21 @@
+// ignore_for_file: avoid_web_libraries_in_flutter, deprecated_member_use
+
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+/// Triggers a browser download via Blob + object URL (Flutter web).
+void saveBrowserFile({
+  required Uint8List bytes,
+  required String filename,
+  required String mimeType,
+}) {
+  final blob = html.Blob([bytes], mimeType);
+  final url = html.Url.createObjectUrlFromBlob(blob);
+  final anchor = html.AnchorElement(href: url)
+    ..setAttribute('download', filename)
+    ..style.display = 'none';
+  html.document.body!.children.add(anchor);
+  anchor.click();
+  anchor.remove();
+  html.Url.revokeObjectUrl(url);
+}

--- a/frontend/lib/domains/analytics/export_repository.dart
+++ b/frontend/lib/domains/analytics/export_repository.dart
@@ -1,0 +1,182 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:frontend/network/openapi.dart' as generated;
+
+enum ExportFormat { csv, json }
+
+extension ExportFormatX on ExportFormat {
+  String get queryValue => name;
+
+  String get extension => name;
+
+  String get mimeType =>
+      this == ExportFormat.csv ? 'text/csv' : 'application/json';
+}
+
+/// Result of a successful analytics export download.
+class ExportPayload {
+  const ExportPayload({
+    required this.bytes,
+    required this.filename,
+    required this.mimeType,
+  });
+
+  final Uint8List bytes;
+  final String filename;
+  final String mimeType;
+}
+
+abstract class ExportRepositoryContract {
+  /// Cohort (or personal) sessions export via `GET /analytics/export/sessions`.
+  Future<ExportPayload> exportSessions({
+    required ExportFormat format,
+    required String scope,
+    DateTime? since,
+    DateTime? until,
+  });
+
+  /// Cohort actions export via `GET /analytics/export/actions` (no session_id).
+  Future<ExportPayload> exportCohortActions({
+    required ExportFormat format,
+    DateTime? since,
+    DateTime? until,
+  });
+
+  /// Per-session actions export via `GET /analytics/export/actions?session_id=`.
+  Future<ExportPayload> exportSessionActions({
+    required String sessionId,
+    required ExportFormat format,
+  });
+}
+
+/// Wraps analytics export endpoints using the shared authenticated [Dio] client.
+///
+/// Generated `AnalyticsApi` deserializes responses as [JsonObject], which breaks
+/// CSV/streaming downloads — this repository requests bytes instead.
+class ExportRepository implements ExportRepositoryContract {
+  ExportRepository({required generated.Openapi openapi}) : _dio = openapi.dio;
+
+  final Dio _dio;
+
+  @override
+  Future<ExportPayload> exportSessions({
+    required ExportFormat format,
+    required String scope,
+    DateTime? since,
+    DateTime? until,
+  }) {
+    return _get(
+      path: '/analytics/export/sessions',
+      query: {
+        'format': format.queryValue,
+        'scope': scope,
+        if (since != null) 'since': since.toUtc().toIso8601String(),
+        if (until != null) 'until': until.toUtc().toIso8601String(),
+      },
+      filename: _filename(
+        base: 'sessions',
+        scope: scope == 'all' ? 'cohort' : 'me',
+        format: format,
+        since: since,
+        until: until,
+      ),
+      mimeType: format.mimeType,
+    );
+  }
+
+  @override
+  Future<ExportPayload> exportCohortActions({
+    required ExportFormat format,
+    DateTime? since,
+    DateTime? until,
+  }) {
+    return _get(
+      path: '/analytics/export/actions',
+      query: {
+        'format': format.queryValue,
+        if (since != null) 'since': since.toUtc().toIso8601String(),
+        if (until != null) 'until': until.toUtc().toIso8601String(),
+      },
+      filename: _filename(
+        base: 'actions',
+        scope: 'cohort',
+        format: format,
+        since: since,
+        until: until,
+      ),
+      mimeType: format.mimeType,
+    );
+  }
+
+  @override
+  Future<ExportPayload> exportSessionActions({
+    required String sessionId,
+    required ExportFormat format,
+  }) {
+    return _get(
+      path: '/analytics/export/actions',
+      query: {'format': format.queryValue, 'session_id': sessionId},
+      filename: _filename(
+        base: 'actions',
+        scope: 'session_$sessionId',
+        format: format,
+      ),
+      mimeType: format.mimeType,
+    );
+  }
+
+  Future<ExportPayload> _get({
+    required String path,
+    required Map<String, dynamic> query,
+    required String filename,
+    required String mimeType,
+  }) async {
+    final response = await _dio.get<List<int>>(
+      path,
+      queryParameters: query,
+      options: Options(
+        responseType: ResponseType.bytes,
+        // OAuth interceptor reads this the same way generated clients do.
+        extra: const {
+          'secure': [
+            {'type': 'oauth2', 'name': 'OAuth2PasswordBearer'},
+          ],
+        },
+      ),
+    );
+    final data = response.data;
+    if (data == null) {
+      throw StateError('Empty export response from $path');
+    }
+    return ExportPayload(
+      bytes: Uint8List.fromList(data),
+      filename: filename,
+      mimeType: mimeType,
+    );
+  }
+
+  static String _filename({
+    required String base,
+    required String scope,
+    required ExportFormat format,
+    DateTime? since,
+    DateTime? until,
+  }) {
+    final parts = <String>[base, scope];
+    if (since != null) {
+      parts.add(_day(since));
+    }
+    if (until != null) {
+      parts.add(_day(until));
+    }
+    return '${parts.join('_')}.${format.extension}';
+  }
+
+  static String _day(DateTime d) {
+    final u = d.toUtc();
+    final m = u.month.toString().padLeft(2, '0');
+    final day = u.day.toString().padLeft(2, '0');
+    return '${u.year}-$m-$day';
+  }
+}

--- a/frontend/lib/features/admin/presentation/admin_sessions_dashboard_screen.dart
+++ b/frontend/lib/features/admin/presentation/admin_sessions_dashboard_screen.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
 import 'package:frontend/common/widgets/app_logo_mark.dart';
 import 'package:frontend/domains/admin/admin_repository.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/auth/auth_repository.dart';
+import 'package:frontend/features/analytics/presentation/analytics_screen.dart';
 import 'package:frontend/network/openapi.dart' as generated;
 import 'package:google_fonts/google_fonts.dart';
 
@@ -15,12 +17,14 @@ class AdminSessionsDashboardScreen extends StatefulWidget {
     required this.adminRepository,
     required this.authRepository,
     required this.buildLoginPage,
+    this.exportRepository,
   });
 
   final AuthSession session;
   final AdminRepositoryContract adminRepository;
   final AuthRepositoryContract authRepository;
   final Widget Function() buildLoginPage;
+  final ExportRepositoryContract? exportRepository;
 
   @override
   State<AdminSessionsDashboardScreen> createState() =>
@@ -147,6 +151,27 @@ class _AdminSessionsDashboardScreenState
         ),
         automaticallyImplyLeading: true,
         actions: [
+          if (widget.exportRepository != null)
+            TextButton.icon(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => AnalyticsScreen(
+                      session: widget.session,
+                      exportRepository: widget.exportRepository!,
+                    ),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.insights_outlined, size: 18),
+              label: Text(
+                'Analytics',
+                style: GoogleFonts.inter(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 13,
+                ),
+              ),
+            ),
           IconButton(
             tooltip: 'Refresh',
             onPressed: _loading ? null : _loadSessions,

--- a/frontend/lib/features/analytics/presentation/analytics_screen.dart
+++ b/frontend/lib/features/analytics/presentation/analytics_screen.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/common/widgets/app_logo_mark.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
+import 'package:frontend/domains/auth/auth_repository.dart';
+import 'package:frontend/features/analytics/presentation/export_controls.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+/// Educator/admin analytics surface with date-window filters and Export.
+class AnalyticsScreen extends StatefulWidget {
+  const AnalyticsScreen({
+    super.key,
+    required this.session,
+    required this.exportRepository,
+  });
+
+  final AuthSession session;
+  final ExportRepositoryContract exportRepository;
+
+  @override
+  State<AnalyticsScreen> createState() => _AnalyticsScreenState();
+}
+
+class _AnalyticsScreenState extends State<AnalyticsScreen> {
+  DateTime? _since;
+  DateTime? _until;
+
+  bool get _canExport {
+    final role = widget.session.user.role.toLowerCase();
+    return role == 'educator' || role == 'admin';
+  }
+
+  Future<void> _pickSince() async {
+    final picked = await showDatePicker(
+      context: context,
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+      initialDate: _since ?? DateTime.now().subtract(const Duration(days: 30)),
+    );
+    if (picked != null) {
+      setState(
+        () => _since = DateTime.utc(picked.year, picked.month, picked.day),
+      );
+    }
+  }
+
+  Future<void> _pickUntil() async {
+    final picked = await showDatePicker(
+      context: context,
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+      initialDate: _until ?? DateTime.now(),
+    );
+    if (picked != null) {
+      setState(
+        () => _until = DateTime.utc(
+          picked.year,
+          picked.month,
+          picked.day,
+          23,
+          59,
+          59,
+        ),
+      );
+    }
+  }
+
+  String _label(DateTime? d, String empty) {
+    if (d == null) return empty;
+    final m = d.month.toString().padLeft(2, '0');
+    final day = d.day.toString().padLeft(2, '0');
+    return '${d.year}-$m-$day';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_canExport) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Analytics')),
+        body: const Center(
+          child: Text('Analytics export is available to educators and admins.'),
+        ),
+      );
+    }
+
+    return Scaffold(
+      backgroundColor: AppColors.canvasBackground,
+      appBar: AppBar(
+        backgroundColor: AppColors.surface,
+        foregroundColor: AppColors.primaryText,
+        elevation: 0,
+        title: const AppLogoMark(compact: true, subtitle: 'Analytics export'),
+        actions: [
+          AnalyticsExportMenuButton(
+            exportRepository: widget.exportRepository,
+            since: _since,
+            until: _until,
+          ),
+          const SizedBox(width: 8),
+        ],
+      ),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 640),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Export cohort data',
+                  style: GoogleFonts.inter(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.primaryText,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Choose an optional time window, then use Export to download '
+                  'sessions or action logs for the full cohort.',
+                  style: GoogleFonts.inter(
+                    fontSize: 14,
+                    color: AppColors.secondaryText,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: [
+                    OutlinedButton.icon(
+                      onPressed: _pickSince,
+                      icon: const Icon(Icons.calendar_today_outlined, size: 18),
+                      label: Text('Since: ${_label(_since, 'any')}'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: _pickUntil,
+                      icon: const Icon(Icons.event_outlined, size: 18),
+                      label: Text('Until: ${_label(_until, 'any')}'),
+                    ),
+                    if (_since != null || _until != null)
+                      TextButton(
+                        onPressed: () => setState(() {
+                          _since = null;
+                          _until = null;
+                        }),
+                        child: const Text('Clear dates'),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 32),
+                Card(
+                  elevation: 0,
+                  color: AppColors.surface,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    side: const BorderSide(color: AppColors.borderSubtle),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Available downloads',
+                          style: GoogleFonts.inter(
+                            fontWeight: FontWeight.w600,
+                            fontSize: 16,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          '• Sessions (CSV / JSON)\n'
+                          '• Actions — this cohort (CSV / JSON)',
+                          style: GoogleFonts.inter(
+                            fontSize: 14,
+                            height: 1.5,
+                            color: AppColors.secondaryText,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        AnalyticsExportMenuButton(
+                          exportRepository: widget.exportRepository,
+                          since: _since,
+                          until: _until,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/analytics/presentation/export_controls.dart
+++ b/frontend/lib/features/analytics/presentation/export_controls.dart
@@ -1,0 +1,237 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:frontend/common/browser_file_download.dart';
+import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+/// Shared export trigger: loading overlay + SnackBar errors (incl. 403).
+Future<void> runAnalyticsExport({
+  required BuildContext context,
+  required Future<ExportPayload> Function() request,
+  BrowserFileSaver? fileSaver,
+}) async {
+  final messenger = ScaffoldMessenger.of(context);
+  showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => const Center(
+      child: Card(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('Preparing download…'),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+
+  try {
+    final payload = await request();
+    if (context.mounted) {
+      Navigator.of(context, rootNavigator: true).pop();
+    }
+    (fileSaver ?? saveBrowserFile)(
+      bytes: payload.bytes,
+      filename: payload.filename,
+      mimeType: payload.mimeType,
+    );
+    messenger.showSnackBar(
+      SnackBar(content: Text('Downloaded ${payload.filename}')),
+    );
+  } on DioException catch (e) {
+    if (context.mounted) {
+      Navigator.of(context, rootNavigator: true).pop();
+    }
+    messenger.showSnackBar(
+      SnackBar(
+        backgroundColor: AppColors.danger,
+        content: Text(_exportErrorMessage(e)),
+      ),
+    );
+  } catch (e) {
+    if (context.mounted) {
+      Navigator.of(context, rootNavigator: true).pop();
+    }
+    messenger.showSnackBar(
+      SnackBar(
+        backgroundColor: AppColors.danger,
+        content: Text('Export failed: $e'),
+      ),
+    );
+  }
+}
+
+String _exportErrorMessage(DioException e) {
+  final code = e.response?.statusCode;
+  final detail = _detail(e);
+  if (code == 403) {
+    return detail ?? 'You do not have permission to export this data.';
+  }
+  if (code == 401) {
+    return 'Session expired. Sign in again and retry the export.';
+  }
+  if (code == 404) {
+    return detail ?? 'Export target not found.';
+  }
+  return detail ?? e.message ?? 'Export failed (${code ?? 'network error'}).';
+}
+
+String? _detail(DioException e) {
+  final data = e.response?.data;
+  if (data is Map && data['detail'] != null) {
+    return data['detail'].toString();
+  }
+  if (data is List<int>) {
+    try {
+      final text = String.fromCharCodes(data);
+      if (text.contains('detail')) return text;
+    } catch (_) {}
+  }
+  return null;
+}
+
+/// Popup menu used on the analytics screen (educator / admin cohort exports).
+class AnalyticsExportMenuButton extends StatelessWidget {
+  const AnalyticsExportMenuButton({
+    super.key,
+    required this.exportRepository,
+    this.since,
+    this.until,
+    this.fileSaver,
+  });
+
+  final ExportRepositoryContract exportRepository;
+  final DateTime? since;
+  final DateTime? until;
+  final BrowserFileSaver? fileSaver;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<String>(
+      tooltip: 'Export',
+      onSelected: (value) {
+        runAnalyticsExport(
+          context: context,
+          fileSaver: fileSaver,
+          request: () => _request(value),
+        );
+      },
+      itemBuilder: (context) => const [
+        PopupMenuItem(value: 'sessions_csv', child: Text('Sessions (CSV)')),
+        PopupMenuItem(value: 'sessions_json', child: Text('Sessions (JSON)')),
+        PopupMenuItem(
+          value: 'actions_csv',
+          child: Text('Actions — this cohort (CSV)'),
+        ),
+        PopupMenuItem(
+          value: 'actions_json',
+          child: Text('Actions — this cohort (JSON)'),
+        ),
+      ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.download_rounded, size: 20),
+            const SizedBox(width: 6),
+            Text(
+              'Export',
+              style: GoogleFonts.inter(fontWeight: FontWeight.w600),
+            ),
+            const Icon(Icons.arrow_drop_down),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<ExportPayload> _request(String value) {
+    switch (value) {
+      case 'sessions_csv':
+        return exportRepository.exportSessions(
+          format: ExportFormat.csv,
+          scope: 'all',
+          since: since,
+          until: until,
+        );
+      case 'sessions_json':
+        return exportRepository.exportSessions(
+          format: ExportFormat.json,
+          scope: 'all',
+          since: since,
+          until: until,
+        );
+      case 'actions_csv':
+        return exportRepository.exportCohortActions(
+          format: ExportFormat.csv,
+          since: since,
+          until: until,
+        );
+      case 'actions_json':
+        return exportRepository.exportCohortActions(
+          format: ExportFormat.json,
+          since: since,
+          until: until,
+        );
+      default:
+        throw StateError('Unknown export option: $value');
+    }
+  }
+}
+
+/// Per-session actions export on the debrief screen.
+class SessionActionsExportButton extends StatelessWidget {
+  const SessionActionsExportButton({
+    super.key,
+    required this.sessionId,
+    required this.exportRepository,
+    this.fileSaver,
+  });
+
+  final String sessionId;
+  final ExportRepositoryContract exportRepository;
+  final BrowserFileSaver? fileSaver;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<ExportFormat>(
+      tooltip: 'Export actions',
+      onSelected: (format) {
+        runAnalyticsExport(
+          context: context,
+          fileSaver: fileSaver,
+          request: () => exportRepository.exportSessionActions(
+            sessionId: sessionId,
+            format: format,
+          ),
+        );
+      },
+      itemBuilder: (context) => const [
+        PopupMenuItem(value: ExportFormat.csv, child: Text('Actions (CSV)')),
+        PopupMenuItem(value: ExportFormat.json, child: Text('Actions (JSON)')),
+      ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.file_download_outlined, size: 20),
+            const SizedBox(width: 4),
+            Text(
+              'Export actions',
+              style: GoogleFonts.inter(fontWeight: FontWeight.w600),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/auth/presentation/login_screen.dart
+++ b/frontend/lib/features/auth/presentation/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/domains/admin/admin_repository.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/auth/auth_repository.dart';
 import 'package:frontend/domains/cases/case_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
@@ -23,6 +24,7 @@ class LoginScreen extends StatefulWidget {
     required this.sessionRepository,
     required this.evaluationRepository,
     required this.communicationRepository,
+    required this.exportRepository,
     this.adminRepository,
   });
 
@@ -31,6 +33,7 @@ class LoginScreen extends StatefulWidget {
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
   final CommunicationRepositoryContract communicationRepository;
+  final ExportRepositoryContract exportRepository;
   final AdminRepositoryContract? adminRepository;
 
   @override
@@ -63,6 +66,7 @@ class _LoginScreenState extends State<LoginScreen> {
         sessionRepository: widget.sessionRepository,
         evaluationRepository: widget.evaluationRepository,
         communicationRepository: widget.communicationRepository,
+        exportRepository: widget.exportRepository,
         adminRepository: widget.adminRepository,
       );
       Navigator.of(

--- a/frontend/lib/features/cases/presentation/case_briefing_screen.dart
+++ b/frontend/lib/features/cases/presentation/case_briefing_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
@@ -17,12 +18,14 @@ class CaseBriefingScreen extends StatefulWidget {
     required this.sessionRepository,
     required this.evaluationRepository,
     required this.communicationRepository,
+    this.exportRepository,
   });
 
   final generated.CaseResponse caseItem;
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
   final CommunicationRepositoryContract communicationRepository;
+  final ExportRepositoryContract? exportRepository;
 
   @override
   State<CaseBriefingScreen> createState() => _CaseBriefingScreenState();
@@ -46,6 +49,7 @@ class _CaseBriefingScreenState extends State<CaseBriefingScreen> {
             sessionRepository: widget.sessionRepository,
             evaluationRepository: widget.evaluationRepository,
             communicationRepository: widget.communicationRepository,
+            exportRepository: widget.exportRepository,
           ),
         ),
       );
@@ -60,6 +64,7 @@ class _CaseBriefingScreenState extends State<CaseBriefingScreen> {
           sessionRepository: widget.sessionRepository,
           evaluationRepository: widget.evaluationRepository,
           communicationRepository: widget.communicationRepository,
+          exportRepository: widget.exportRepository,
         );
         return;
       }

--- a/frontend/lib/features/cases/presentation/case_library_screen.dart
+++ b/frontend/lib/features/cases/presentation/case_library_screen.dart
@@ -4,12 +4,14 @@ import 'package:frontend/common/theme/app_colors.dart';
 import 'package:frontend/common/widgets/app_library_top_bar.dart';
 import 'package:frontend/common/widgets/app_page_footer.dart';
 import 'package:frontend/domains/admin/admin_repository.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/auth/auth_repository.dart';
 import 'package:frontend/domains/cases/case_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
 import 'package:frontend/features/admin/presentation/admin_sessions_dashboard_screen.dart';
+import 'package:frontend/features/analytics/presentation/analytics_screen.dart';
 import 'package:frontend/features/cases/presentation/case_briefing_screen.dart';
 import 'package:frontend/features/cases/presentation/educator_case_manage_panel.dart';
 import 'package:frontend/features/evaluation/presentation/debrief_screen.dart';
@@ -29,6 +31,7 @@ class CaseLibraryScreen extends StatefulWidget {
     required this.communicationRepository,
     required this.authRepository,
     required this.adminRepository,
+    required this.exportRepository,
     required this.buildLoginPage,
   });
 
@@ -39,6 +42,7 @@ class CaseLibraryScreen extends StatefulWidget {
   final CommunicationRepositoryContract communicationRepository;
   final AuthRepositoryContract authRepository;
   final AdminRepositoryContract? adminRepository;
+  final ExportRepositoryContract exportRepository;
   final Widget Function() buildLoginPage;
 
   @override
@@ -111,6 +115,7 @@ class _CaseLibraryScreenState extends State<CaseLibraryScreen> with RouteAware {
       sessionRepository: widget.sessionRepository,
       evaluationRepository: widget.evaluationRepository,
       communicationRepository: widget.communicationRepository,
+      exportRepository: widget.exportRepository,
     );
     if (mounted) await _loadCompletedSessions();
   }
@@ -132,7 +137,12 @@ class _CaseLibraryScreenState extends State<CaseLibraryScreen> with RouteAware {
       final completed = await widget.sessionRepository.listCompleted();
       final byCaseId = <String, String>{};
       for (final session in completed) {
-        byCaseId.putIfAbsent(session.caseId, () => session.sessionId);
+        final caseId = session.caseId.trim();
+        final sessionId = session.sessionId.trim();
+        // Skip malformed rows so we never show Evaluation for the wrong card.
+        if (caseId.isEmpty || sessionId.isEmpty) continue;
+        if (session.status != 'completed') continue;
+        byCaseId.putIfAbsent(caseId, () => sessionId);
       }
       if (mounted) {
         setState(() => _completedSessionsByCaseId = byCaseId);
@@ -239,6 +249,7 @@ class _CaseLibraryScreenState extends State<CaseLibraryScreen> with RouteAware {
                             evaluationRepository: widget.evaluationRepository,
                             communicationRepository:
                                 widget.communicationRepository,
+                            exportRepository: widget.exportRepository,
                           ),
                         ),
                       )
@@ -260,6 +271,7 @@ class _CaseLibraryScreenState extends State<CaseLibraryScreen> with RouteAware {
                             evaluationRepository: widget.evaluationRepository,
                             communicationRepository:
                                 widget.communicationRepository,
+                            exportRepository: widget.exportRepository,
                           ),
                         ),
                       )
@@ -276,7 +288,20 @@ class _CaseLibraryScreenState extends State<CaseLibraryScreen> with RouteAware {
                         session: widget.session,
                         adminRepository: widget.adminRepository!,
                         authRepository: widget.authRepository,
+                        exportRepository: widget.exportRepository,
                         buildLoginPage: widget.buildLoginPage,
+                      ),
+                    ),
+                  );
+                }
+
+                void openAnalytics() {
+                  if (!_isCaseManager) return;
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => AnalyticsScreen(
+                        session: widget.session,
+                        exportRepository: widget.exportRepository,
                       ),
                     ),
                   );
@@ -335,15 +360,33 @@ class _CaseLibraryScreenState extends State<CaseLibraryScreen> with RouteAware {
                           }
                         }),
                       ),
-                    if (canOpenAdminTrace)
+                    if (canOpenAdminTrace || _isCaseManager)
                       Align(
                         alignment: Alignment.centerRight,
                         child: Padding(
                           padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-                          child: OutlinedButton.icon(
-                            onPressed: openAdminTrace,
-                            icon: const Icon(Icons.timeline_rounded, size: 18),
-                            label: const Text('Student Sessions'),
+                          child: Wrap(
+                            spacing: 8,
+                            children: [
+                              if (_isCaseManager)
+                                OutlinedButton.icon(
+                                  onPressed: openAnalytics,
+                                  icon: const Icon(
+                                    Icons.insights_outlined,
+                                    size: 18,
+                                  ),
+                                  label: const Text('Analytics'),
+                                ),
+                              if (canOpenAdminTrace)
+                                OutlinedButton.icon(
+                                  onPressed: openAdminTrace,
+                                  icon: const Icon(
+                                    Icons.timeline_rounded,
+                                    size: 18,
+                                  ),
+                                  label: const Text('Student Sessions'),
+                                ),
+                            ],
                           ),
                         ),
                       ),
@@ -931,17 +974,16 @@ class _MainPane extends StatelessWidget {
                         child: _LibraryCaseCard(
                           caseItem: item,
                           onStart: () => onOpenCase(item),
-                          evaluationSessionId:
-                              completedSessionsByCaseId[item.caseId],
-                          onOpenEvaluation: onOpenEvaluation == null
-                              ? null
-                              : () {
-                                  final sid =
-                                      completedSessionsByCaseId[item.caseId];
-                                  if (sid != null) {
-                                    onOpenEvaluation!(item, sid);
-                                  }
-                                },
+                          evaluationSessionId: _evaluationSessionIdFor(
+                            completedSessionsByCaseId,
+                            item.caseId,
+                          ),
+                          onOpenEvaluation: _evaluationCallbackFor(
+                            item: item,
+                            completedSessionsByCaseId:
+                                completedSessionsByCaseId,
+                            onOpenEvaluation: onOpenEvaluation,
+                          ),
                           showManageActions: showCardActions,
                           actionBusy: managingCaseId == item.id,
                           onEdit: onEducatorEdit == null
@@ -967,17 +1009,15 @@ class _MainPane extends StatelessWidget {
                       caseItem: item,
                       compact: true,
                       onStart: () => onOpenCase(item),
-                      evaluationSessionId:
-                          completedSessionsByCaseId[item.caseId],
-                      onOpenEvaluation: onOpenEvaluation == null
-                          ? null
-                          : () {
-                              final sid =
-                                  completedSessionsByCaseId[item.caseId];
-                              if (sid != null) {
-                                onOpenEvaluation!(item, sid);
-                              }
-                            },
+                      evaluationSessionId: _evaluationSessionIdFor(
+                        completedSessionsByCaseId,
+                        item.caseId,
+                      ),
+                      onOpenEvaluation: _evaluationCallbackFor(
+                        item: item,
+                        completedSessionsByCaseId: completedSessionsByCaseId,
+                        onOpenEvaluation: onOpenEvaluation,
+                      ),
                       showManageActions: showCardActions,
                       actionBusy: managingCaseId == item.id,
                       onEdit: onEducatorEdit == null
@@ -1002,6 +1042,27 @@ class _MainPane extends StatelessWidget {
       ],
     );
   }
+}
+
+String? _evaluationSessionIdFor(
+  Map<String, String> completedSessionsByCaseId,
+  String caseId,
+) {
+  final sid = completedSessionsByCaseId[caseId];
+  if (sid == null || sid.trim().isEmpty) return null;
+  return sid;
+}
+
+VoidCallback? _evaluationCallbackFor({
+  required generated.CaseResponse item,
+  required Map<String, String> completedSessionsByCaseId,
+  required void Function(generated.CaseResponse caseItem, String sessionId)?
+  onOpenEvaluation,
+}) {
+  if (onOpenEvaluation == null) return null;
+  final sid = _evaluationSessionIdFor(completedSessionsByCaseId, item.caseId);
+  if (sid == null) return null;
+  return () => onOpenEvaluation(item, sid);
 }
 
 class _SortDropdown extends StatelessWidget {
@@ -1320,74 +1381,110 @@ class _LibraryCaseCard extends StatelessWidget {
             ),
             const SizedBox(height: 10),
           ],
-          Row(
+          Wrap(
+            spacing: 12,
+            runSpacing: 10,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            alignment: WrapAlignment.spaceBetween,
             children: [
-              Icon(
-                Icons.schedule_rounded,
-                size: 16,
-                color: AppColors.tertiaryText,
+              Wrap(
+                spacing: 16,
+                runSpacing: 4,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.schedule_rounded,
+                        size: 16,
+                        color: AppColors.tertiaryText,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        '~${(caseItem.age / 10).ceil() * 5} min',
+                        style: GoogleFonts.inter(
+                          fontSize: 12,
+                          color: AppColors.tertiaryText,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.signal_cellular_alt_rounded,
+                        size: 16,
+                        color: _difficultyColor,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        _difficultyLabel,
+                        style: GoogleFonts.inter(
+                          fontSize: 12,
+                          color: AppColors.tertiaryText,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
               ),
-              const SizedBox(width: 4),
-              Text(
-                '~${(caseItem.age / 10).ceil() * 5} min',
-                style: GoogleFonts.inter(
-                  fontSize: 12,
-                  color: AppColors.tertiaryText,
-                ),
-              ),
-              const SizedBox(width: 16),
-              Icon(
-                Icons.signal_cellular_alt_rounded,
-                size: 16,
-                color: _difficultyColor,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                _difficultyLabel,
-                style: GoogleFonts.inter(
-                  fontSize: 12,
-                  color: AppColors.tertiaryText,
-                ),
-              ),
-              const Spacer(),
-              if (!showManageActions &&
-                  evaluationSessionId != null &&
-                  onOpenEvaluation != null) ...[
-                TextButton(
-                  onPressed: actionBusy ? null : onOpenEvaluation,
-                  child: Text(
-                    'Evaluation',
-                    style: GoogleFonts.inter(
-                      fontWeight: FontWeight.w600,
-                      fontSize: 13,
+              Wrap(
+                spacing: 4,
+                runSpacing: 4,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                alignment: WrapAlignment.end,
+                children: [
+                  if (_showEvaluationButton)
+                    TextButton(
+                      onPressed: actionBusy ? null : onOpenEvaluation,
+                      style: TextButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        minimumSize: Size.zero,
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                      child: Text(
+                        'Evaluation',
+                        style: GoogleFonts.inter(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ),
+                  FilledButton(
+                    onPressed: actionBusy ? null : onStart,
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 10,
+                      ),
+                      minimumSize: Size.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: Text(
+                      'Start Case',
+                      style: GoogleFonts.inter(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 13,
+                      ),
                     ),
                   ),
-                ),
-                const SizedBox(width: 4),
-              ],
-              FilledButton(
-                onPressed: actionBusy ? null : onStart,
-                style: FilledButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 10,
-                  ),
-                  minimumSize: Size.zero,
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                ),
-                child: Text(
-                  'Start Case',
-                  style: GoogleFonts.inter(
-                    fontWeight: FontWeight.w600,
-                    fontSize: 13,
-                  ),
-                ),
+                ],
               ),
             ],
           ),
         ],
       ),
     );
+  }
+
+  bool get _showEvaluationButton {
+    final sid = evaluationSessionId;
+    return !showManageActions &&
+        sid != null &&
+        sid.isNotEmpty &&
+        onOpenEvaluation != null;
   }
 }
 

--- a/frontend/lib/features/cases/presentation/case_simulation_screen.dart
+++ b/frontend/lib/features/cases/presentation/case_simulation_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_chat_ui/flutter_chat_ui.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:frontend/common/theme/app_colors.dart';
 import 'package:frontend/common/widgets/app_logo_mark.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_hydration.dart';
@@ -26,6 +27,7 @@ class CaseSimulationScreen extends StatefulWidget {
     required this.sessionRepository,
     required this.evaluationRepository,
     required this.communicationRepository,
+    this.exportRepository,
     this.initialHydration,
   });
 
@@ -34,6 +36,7 @@ class CaseSimulationScreen extends StatefulWidget {
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
   final CommunicationRepositoryContract communicationRepository;
+  final ExportRepositoryContract? exportRepository;
   final SimulationHydration? initialHydration;
 
   @override
@@ -380,6 +383,7 @@ class _CaseSimulationScreenState extends State<CaseSimulationScreen>
           sessionRepository: widget.sessionRepository,
           evaluationRepository: widget.evaluationRepository,
           communicationRepository: widget.communicationRepository,
+          exportRepository: widget.exportRepository,
           initialConclusions: _savedConclusions,
         ),
       ),

--- a/frontend/lib/features/cases/presentation/simulation_conclusions_screen.dart
+++ b/frontend/lib/features/cases/presentation/simulation_conclusions_screen.dart
@@ -3,6 +3,7 @@ import 'package:built_value/json_object.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
@@ -19,6 +20,7 @@ class SimulationConclusionsScreen extends StatefulWidget {
     required this.sessionRepository,
     required this.evaluationRepository,
     required this.communicationRepository,
+    this.exportRepository,
     this.initialConclusions,
   });
 
@@ -27,6 +29,7 @@ class SimulationConclusionsScreen extends StatefulWidget {
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
   final CommunicationRepositoryContract communicationRepository;
+  final ExportRepositoryContract? exportRepository;
   final BuiltMap<String, JsonObject?>? initialConclusions;
 
   @override
@@ -437,6 +440,7 @@ class _SimulationConclusionsScreenState
             sessionId: widget.sessionId,
             evaluationRepository: widget.evaluationRepository,
             communicationRepository: widget.communicationRepository,
+            exportRepository: widget.exportRepository,
           ),
         ),
       );

--- a/frontend/lib/features/evaluation/presentation/debrief_screen.dart
+++ b/frontend/lib/features/evaluation/presentation/debrief_screen.dart
@@ -3,8 +3,10 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
 import 'package:frontend/common/widgets/structured_conclusions_summary.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
+import 'package:frontend/features/analytics/presentation/export_controls.dart';
 import 'package:frontend/features/evaluation/presentation/communication_panel.dart';
 import 'package:frontend/network/openapi.dart' as generated;
 import 'package:google_fonts/google_fonts.dart';
@@ -21,12 +23,16 @@ class DebriefScreen extends StatefulWidget {
     required this.sessionId,
     required this.evaluationRepository,
     required this.communicationRepository,
+    this.exportRepository,
   });
 
   final generated.CaseResponse caseItem;
   final String sessionId;
   final EvaluationRepositoryContract evaluationRepository;
   final CommunicationRepositoryContract communicationRepository;
+
+  /// When set, shows **Export actions** for the current session (owner / staff).
+  final ExportRepositoryContract? exportRepository;
 
   @override
   State<DebriefScreen> createState() => _DebriefScreenState();
@@ -129,6 +135,11 @@ class _DebriefScreenState extends State<DebriefScreen>
           style: GoogleFonts.inter(fontWeight: FontWeight.w700, fontSize: 18),
         ),
         actions: [
+          if (widget.exportRepository != null)
+            SessionActionsExportButton(
+              sessionId: widget.sessionId,
+              exportRepository: widget.exportRepository!,
+            ),
           TextButton.icon(
             onPressed: () => _goToCaseLibrary(context),
             icon: const Icon(Icons.grid_view_rounded, size: 20),

--- a/frontend/lib/features/sessions/presentation/duplicate_start_dialog.dart
+++ b/frontend/lib/features/sessions/presentation/duplicate_start_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
@@ -18,6 +19,7 @@ Future<void> showDuplicateStartDialog({
   required SessionRepositoryContract sessionRepository,
   required EvaluationRepositoryContract evaluationRepository,
   required CommunicationRepositoryContract communicationRepository,
+  ExportRepositoryContract? exportRepository,
 }) async {
   await showDialog<void>(
     context: context,
@@ -27,6 +29,7 @@ Future<void> showDuplicateStartDialog({
       sessionRepository: sessionRepository,
       evaluationRepository: evaluationRepository,
       communicationRepository: communicationRepository,
+      exportRepository: exportRepository,
     ),
   );
 }
@@ -38,6 +41,7 @@ class _DuplicateStartDialog extends StatefulWidget {
     required this.sessionRepository,
     required this.evaluationRepository,
     required this.communicationRepository,
+    this.exportRepository,
   });
 
   final generated.CaseResponse caseItem;
@@ -45,6 +49,7 @@ class _DuplicateStartDialog extends StatefulWidget {
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
   final CommunicationRepositoryContract communicationRepository;
+  final ExportRepositoryContract? exportRepository;
 
   @override
   State<_DuplicateStartDialog> createState() => _DuplicateStartDialogState();
@@ -68,6 +73,7 @@ class _DuplicateStartDialogState extends State<_DuplicateStartDialog> {
       sessionRepository: widget.sessionRepository,
       evaluationRepository: widget.evaluationRepository,
       communicationRepository: widget.communicationRepository,
+      exportRepository: widget.exportRepository,
     );
   }
 
@@ -91,6 +97,7 @@ class _DuplicateStartDialogState extends State<_DuplicateStartDialog> {
             sessionRepository: widget.sessionRepository,
             evaluationRepository: widget.evaluationRepository,
             communicationRepository: widget.communicationRepository,
+            exportRepository: widget.exportRepository,
           ),
         ),
       );

--- a/frontend/lib/features/sessions/presentation/resume_session_flow.dart
+++ b/frontend/lib/features/sessions/presentation/resume_session_flow.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_hydration.dart';
@@ -14,6 +15,7 @@ Future<void> resumeSessionAndNavigate({
   required SessionRepositoryContract sessionRepository,
   required EvaluationRepositoryContract evaluationRepository,
   required CommunicationRepositoryContract communicationRepository,
+  ExportRepositoryContract? exportRepository,
 }) async {
   if (!context.mounted) return;
   showDialog<void>(
@@ -38,6 +40,7 @@ Future<void> resumeSessionAndNavigate({
           sessionRepository: sessionRepository,
           evaluationRepository: evaluationRepository,
           communicationRepository: communicationRepository,
+          exportRepository: exportRepository,
           initialHydration: hydration,
         ),
       ),

--- a/frontend/lib/features/sessions/presentation/unfinished_sessions_sheet.dart
+++ b/frontend/lib/features/sessions/presentation/unfinished_sessions_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/common/theme/app_colors.dart';
+import 'package:frontend/domains/analytics/export_repository.dart';
 import 'package:frontend/domains/evaluation/communication_repository.dart';
 import 'package:frontend/domains/evaluation/evaluation_repository.dart';
 import 'package:frontend/domains/sessions/session_repository.dart';
@@ -16,6 +17,7 @@ Future<void> showUnfinishedSessionsSheet({
   required SessionRepositoryContract sessionRepository,
   required EvaluationRepositoryContract evaluationRepository,
   required CommunicationRepositoryContract communicationRepository,
+  ExportRepositoryContract? exportRepository,
 }) async {
   final maxHeight = MediaQuery.sizeOf(context).height * 0.62;
   await showModalBottomSheet<void>(
@@ -28,6 +30,7 @@ Future<void> showUnfinishedSessionsSheet({
       sessionRepository: sessionRepository,
       evaluationRepository: evaluationRepository,
       communicationRepository: communicationRepository,
+      exportRepository: exportRepository,
     ),
   );
 }
@@ -37,11 +40,13 @@ class _UnfinishedSessionsBody extends StatefulWidget {
     required this.sessionRepository,
     required this.evaluationRepository,
     required this.communicationRepository,
+    this.exportRepository,
   });
 
   final SessionRepositoryContract sessionRepository;
   final EvaluationRepositoryContract evaluationRepository;
   final CommunicationRepositoryContract communicationRepository;
+  final ExportRepositoryContract? exportRepository;
 
   @override
   State<_UnfinishedSessionsBody> createState() =>
@@ -110,6 +115,7 @@ class _UnfinishedSessionsBodyState extends State<_UnfinishedSessionsBody> {
       sessionRepository: widget.sessionRepository,
       evaluationRepository: widget.evaluationRepository,
       communicationRepository: widget.communicationRepository,
+      exportRepository: widget.exportRepository,
     );
     if (mounted) {
       setState(() => _busySessionIds.remove(item.sessionId));

--- a/frontend/lib/network/openapi.dart
+++ b/frontend/lib/network/openapi.dart
@@ -11,6 +11,7 @@ export 'package:frontend/network/src/serializers.dart';
 export 'package:frontend/network/src/model/date.dart';
 
 export 'package:frontend/network/src/api/admin_api.dart';
+export 'package:frontend/network/src/api/analytics_api.dart';
 export 'package:frontend/network/src/api/auth_api.dart';
 export 'package:frontend/network/src/api/cases_api.dart';
 export 'package:frontend/network/src/api/communication_evaluation_api.dart';

--- a/frontend/lib/network/src/api.dart
+++ b/frontend/lib/network/src/api.dart
@@ -10,6 +10,7 @@ import 'package:frontend/network/src/auth/basic_auth.dart';
 import 'package:frontend/network/src/auth/bearer_auth.dart';
 import 'package:frontend/network/src/auth/oauth.dart';
 import 'package:frontend/network/src/api/admin_api.dart';
+import 'package:frontend/network/src/api/analytics_api.dart';
 import 'package:frontend/network/src/api/auth_api.dart';
 import 'package:frontend/network/src/api/cases_api.dart';
 import 'package:frontend/network/src/api/communication_evaluation_api.dart';
@@ -147,6 +148,12 @@ class Openapi {
   /// by doing that all interceptors will not be executed
   AdminApi getAdminApi() {
     return AdminApi(dio, serializers);
+  }
+
+  /// Get AnalyticsApi instance, base route and serializer can be overridden by a given but be careful,
+  /// by doing that all interceptors will not be executed
+  AnalyticsApi getAnalyticsApi() {
+    return AnalyticsApi(dio, serializers);
   }
 
   /// Get AuthApi instance, base route and serializer can be overridden by a given but be careful,

--- a/frontend/lib/network/src/api/analytics_api.dart
+++ b/frontend/lib/network/src/api/analytics_api.dart
@@ -1,0 +1,245 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+import 'dart:async';
+
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'package:dio/dio.dart';
+
+import 'package:built_value/json_object.dart';
+import 'package:frontend/network/src/api_util.dart';
+import 'package:frontend/network/src/model/http_validation_error.dart';
+
+class AnalyticsApi {
+  final Dio _dio;
+
+  final Serializers _serializers;
+
+  const AnalyticsApi(this._dio, this._serializers);
+
+  /// Export Actions
+  ///
+  ///
+  /// Parameters:
+  /// * [format]
+  /// * [sessionId]
+  /// * [since]
+  /// * [until]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [JsonObject] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<JsonObject>> exportActionsAnalyticsExportActionsGet({
+    String? format = 'csv',
+    String? sessionId,
+    DateTime? since,
+    DateTime? until,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/analytics/export/actions';
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{...?headers},
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {'type': 'oauth2', 'name': 'OAuth2PasswordBearer'},
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    // Omit optional filters when unset — encodeQueryParameter(null) becomes ''.
+    final _queryParameters = <String, dynamic>{
+      if (format != null)
+        r'format': encodeQueryParameter(
+          _serializers,
+          format,
+          const FullType(String),
+        ),
+      if (sessionId != null && sessionId.isNotEmpty)
+        r'session_id': encodeQueryParameter(
+          _serializers,
+          sessionId,
+          const FullType(String),
+        ),
+      if (since != null)
+        r'since': encodeQueryParameter(
+          _serializers,
+          since,
+          const FullType(DateTime),
+        ),
+      if (until != null)
+        r'until': encodeQueryParameter(
+          _serializers,
+          until,
+          const FullType(DateTime),
+        ),
+    };
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      queryParameters: _queryParameters,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    JsonObject? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null
+          ? null
+          : _serializers.deserialize(
+                  rawResponse,
+                  specifiedType: const FullType(JsonObject),
+                )
+                as JsonObject;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<JsonObject>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// Export Sessions
+  ///
+  ///
+  /// Parameters:
+  /// * [format]
+  /// * [scope]
+  /// * [since]
+  /// * [until]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [JsonObject] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<JsonObject>> exportSessionsAnalyticsExportSessionsGet({
+    String? format = 'csv',
+    String? scope = 'me',
+    DateTime? since,
+    DateTime? until,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/analytics/export/sessions';
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{...?headers},
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {'type': 'oauth2', 'name': 'OAuth2PasswordBearer'},
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    // Omit optional filters when unset — encodeQueryParameter(null) becomes ''.
+    final _queryParameters = <String, dynamic>{
+      if (format != null)
+        r'format': encodeQueryParameter(
+          _serializers,
+          format,
+          const FullType(String),
+        ),
+      if (scope != null)
+        r'scope': encodeQueryParameter(
+          _serializers,
+          scope,
+          const FullType(String),
+        ),
+      if (since != null)
+        r'since': encodeQueryParameter(
+          _serializers,
+          since,
+          const FullType(DateTime),
+        ),
+      if (until != null)
+        r'until': encodeQueryParameter(
+          _serializers,
+          until,
+          const FullType(DateTime),
+        ),
+    };
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      queryParameters: _queryParameters,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    JsonObject? _responseData;
+
+    try {
+      final rawResponse = _response.data;
+      _responseData = rawResponse == null
+          ? null
+          : _serializers.deserialize(
+                  rawResponse,
+                  specifiedType: const FullType(JsonObject),
+                )
+                as JsonObject;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<JsonObject>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+}

--- a/frontend/lib/network/src/model/create_case_request.dart
+++ b/frontend/lib/network/src/model/create_case_request.dart
@@ -320,11 +320,12 @@ class _$CreateCaseRequestSerializer
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(String),
                     ]),
                   )
-                  as BuiltList<String>;
+                  as BuiltList<String>?;
+          if (valueDes == null) continue;
           result.tags.replace(valueDes);
           break;
         case r'age':
@@ -355,11 +356,12 @@ class _$CreateCaseRequestSerializer
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(String),
                     ]),
                   )
-                  as BuiltList<String>;
+                  as BuiltList<String>?;
+          if (valueDes == null) continue;
           result.tonePresets.replace(valueDes);
           break;
         case r'chief_complaint':
@@ -402,11 +404,12 @@ class _$CreateCaseRequestSerializer
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(String),
                     ]),
                   )
-                  as BuiltList<String>;
+                  as BuiltList<String>?;
+          if (valueDes == null) continue;
           result.differential.replace(valueDes);
           break;
         case r'severity_or_stage':
@@ -450,9 +453,12 @@ class _$CreateCaseRequestSerializer
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(CreateCaseRequestStatusEnum),
+                    specifiedType: const FullType.nullable(
+                      CreateCaseRequestStatusEnum,
+                    ),
                   )
-                  as CreateCaseRequestStatusEnum;
+                  as CreateCaseRequestStatusEnum?;
+          if (valueDes == null) continue;
           result.status = valueDes;
           break;
         default:

--- a/frontend/lib/network/src/model/http_validation_error.dart
+++ b/frontend/lib/network/src/model/http_validation_error.dart
@@ -87,11 +87,12 @@ class _$HTTPValidationErrorSerializer
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(ValidationError),
                     ]),
                   )
-                  as BuiltList<ValidationError>;
+                  as BuiltList<ValidationError>?;
+          if (valueDes == null) continue;
           result.detail.replace(valueDes);
           break;
         default:

--- a/frontend/lib/network/src/model/investigations_request.dart
+++ b/frontend/lib/network/src/model/investigations_request.dart
@@ -113,11 +113,12 @@ class _$InvestigationsRequestSerializer
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(String),
                     ]),
                   )
-                  as BuiltList<String>;
+                  as BuiltList<String>?;
+          if (valueDes == null) continue;
           result.catalogHints.replace(valueDes);
           break;
         case r'expected':
@@ -133,11 +134,12 @@ class _$InvestigationsRequestSerializer
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(InvestigationResultRequest),
                     ]),
                   )
-                  as BuiltList<InvestigationResultRequest>;
+                  as BuiltList<InvestigationResultRequest>?;
+          if (valueDes == null) continue;
           result.results.replace(valueDes);
           break;
         default:

--- a/frontend/lib/network/src/model/scoring_request.dart
+++ b/frontend/lib/network/src/model/scoring_request.dart
@@ -159,22 +159,24 @@ class _$ScoringRequestSerializer
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(AcceptableAnswerRequest),
                     ]),
                   )
-                  as BuiltList<AcceptableAnswerRequest>;
+                  as BuiltList<AcceptableAnswerRequest>?;
+          if (valueDes == null) continue;
           result.acceptableAnswers.replace(valueDes);
           break;
         case r'critical_safety_errors':
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(String),
                     ]),
                   )
-                  as BuiltList<String>;
+                  as BuiltList<String>?;
+          if (valueDes == null) continue;
           result.criticalSafetyErrors.replace(valueDes);
           break;
         default:

--- a/frontend/lib/network/src/model/token_response.dart
+++ b/frontend/lib/network/src/model/token_response.dart
@@ -117,9 +117,10 @@ class _$TokenResponseSerializer implements PrimitiveSerializer<TokenResponse> {
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(String),
+                    specifiedType: const FullType.nullable(String),
                   )
-                  as String;
+                  as String?;
+          if (valueDes == null) continue;
           result.tokenType = valueDes;
           break;
         default:

--- a/frontend/lib/network/src/model/treatment_plan.dart
+++ b/frontend/lib/network/src/model/treatment_plan.dart
@@ -120,44 +120,48 @@ class _$TreatmentPlanSerializer implements PrimitiveSerializer<TreatmentPlan> {
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(Medication),
                     ]),
                   )
-                  as BuiltList<Medication>;
+                  as BuiltList<Medication>?;
+          if (valueDes == null) continue;
           result.medications.replace(valueDes);
           break;
         case r'non_pharmacological':
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(String),
                     ]),
                   )
-                  as BuiltList<String>;
+                  as BuiltList<String>?;
+          if (valueDes == null) continue;
           result.nonPharmacological.replace(valueDes);
           break;
         case r'referrals':
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(String),
                     ]),
                   )
-                  as BuiltList<String>;
+                  as BuiltList<String>?;
+          if (valueDes == null) continue;
           result.referrals.replace(valueDes);
           break;
         case r'follow_up':
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(BuiltList, [
+                    specifiedType: const FullType.nullable(BuiltList, [
                       FullType(String),
                     ]),
                   )
-                  as BuiltList<String>;
+                  as BuiltList<String>?;
+          if (valueDes == null) continue;
           result.followUp.replace(valueDes);
           break;
         default:

--- a/frontend/lib/network/src/model/validation_error.dart
+++ b/frontend/lib/network/src/model/validation_error.dart
@@ -162,9 +162,10 @@ class _$ValidationErrorSerializer
           final valueDes =
               serializers.deserialize(
                     value,
-                    specifiedType: const FullType(JsonObject),
+                    specifiedType: const FullType.nullable(JsonObject),
                   )
-                  as JsonObject;
+                  as JsonObject?;
+          if (valueDes == null) continue;
           result.ctx = valueDes;
           break;
         default:

--- a/frontend/lib/network/src/serializers.dart
+++ b/frontend/lib/network/src/serializers.dart
@@ -128,16 +128,85 @@ part 'serializers.g.dart';
 Serializers serializers =
     (_$serializers.toBuilder()
           ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(EvaluationFindingResponse)]),
+            () => ListBuilder<EvaluationFindingResponse>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(SessionSummary)]),
+            () => ListBuilder<SessionSummary>(),
+          )
+          ..addBuilderFactory(
             const FullType(BuiltList, [FullType(ActiveSessionItem)]),
             () => ListBuilder<ActiveSessionItem>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(AvailableTestItem)]),
+            () => ListBuilder<AvailableTestItem>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(ActionLogEntry)]),
+            () => ListBuilder<ActionLogEntry>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(InvestigationResultResponse)]),
+            () => ListBuilder<InvestigationResultResponse>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(DifferentialDiagnosisItem)]),
+            () => ListBuilder<DifferentialDiagnosisItem>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(ChatMessage)]),
+            () => ListBuilder<ChatMessage>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(AcceptableAnswerResponse)]),
+            () => ListBuilder<AcceptableAnswerResponse>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(InvestigationResultRequest)]),
+            () => ListBuilder<InvestigationResultRequest>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(AcceptableAnswerRequest)]),
+            () => ListBuilder<AcceptableAnswerRequest>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(LocationInner)]),
+            () => ListBuilder<LocationInner>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(SessionResponse)]),
+            () => ListBuilder<SessionResponse>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltMap, [
+              FullType(String),
+              FullType.nullable(JsonObject),
+            ]),
+            () => MapBuilder<String, JsonObject?>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(ValidationError)]),
+            () => ListBuilder<ValidationError>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltList, [FullType(CaseResponse)]),
             () => ListBuilder<CaseResponse>(),
           )
           ..addBuilderFactory(
-            const FullType(BuiltList, [FullType(SessionResponse)]),
-            () => ListBuilder<SessionResponse>(),
+            const FullType(BuiltList, [FullType(Medication)]),
+            () => ListBuilder<Medication>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(String)]),
+            () => ListBuilder<String>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [
+              FullType(CommunicationCriterionResponse),
+            ]),
+            () => ListBuilder<CommunicationCriterionResponse>(),
           )
           ..add(const OneOfSerializer())
           ..add(const AnyOfSerializer())

--- a/frontend/openapi/openapi.bash
+++ b/frontend/openapi/openapi.bash
@@ -70,6 +70,35 @@ _admin_query_new = """    // Omit optional filters when unset — encodeQueryPar
       if (onDate != null) r'on_date': encodeQueryParameter(_serializers, onDate, const FullType(Date)),
     };"""
 
+_analytics_actions_query_old = """    final _queryParameters = <String, dynamic>{
+      if (format != null) r'format': encodeQueryParameter(_serializers, format, const FullType(String)),
+      r'session_id': encodeQueryParameter(_serializers, sessionId, const FullType(String)),
+      r'since': encodeQueryParameter(_serializers, since, const FullType(DateTime)),
+      r'until': encodeQueryParameter(_serializers, until, const FullType(DateTime)),
+    };"""
+_analytics_actions_query_new = """    // Omit optional filters when unset — encodeQueryParameter(null) becomes ''.
+    final _queryParameters = <String, dynamic>{
+      if (format != null) r'format': encodeQueryParameter(_serializers, format, const FullType(String)),
+      if (sessionId != null && sessionId.isNotEmpty)
+        r'session_id': encodeQueryParameter(_serializers, sessionId, const FullType(String)),
+      if (since != null) r'since': encodeQueryParameter(_serializers, since, const FullType(DateTime)),
+      if (until != null) r'until': encodeQueryParameter(_serializers, until, const FullType(DateTime)),
+    };"""
+
+_analytics_sessions_query_old = """    final _queryParameters = <String, dynamic>{
+      if (format != null) r'format': encodeQueryParameter(_serializers, format, const FullType(String)),
+      if (scope != null) r'scope': encodeQueryParameter(_serializers, scope, const FullType(String)),
+      r'since': encodeQueryParameter(_serializers, since, const FullType(DateTime)),
+      r'until': encodeQueryParameter(_serializers, until, const FullType(DateTime)),
+    };"""
+_analytics_sessions_query_new = """    // Omit optional filters when unset — encodeQueryParameter(null) becomes ''.
+    final _queryParameters = <String, dynamic>{
+      if (format != null) r'format': encodeQueryParameter(_serializers, format, const FullType(String)),
+      if (scope != null) r'scope': encodeQueryParameter(_serializers, scope, const FullType(String)),
+      if (since != null) r'since': encodeQueryParameter(_serializers, since, const FullType(DateTime)),
+      if (until != null) r'until': encodeQueryParameter(_serializers, until, const FullType(DateTime)),
+    };"""
+
 for file in target.rglob("*.dart"):
     text = file.read_text()
     text = text.replace(
@@ -80,6 +109,9 @@ for file in target.rglob("*.dart"):
         text = text.replace(_cases_query_old, _cases_query_new)
     if file.name == "admin_api.dart":
         text = text.replace(_admin_query_old, _admin_query_new)
+    if file.name == "analytics_api.dart":
+        text = text.replace(_analytics_actions_query_old, _analytics_actions_query_new)
+        text = text.replace(_analytics_sessions_query_old, _analytics_sessions_query_new)
     file.write_text(text)
 PY
 

--- a/frontend/openapi/openapi.json
+++ b/frontend/openapi/openapi.json
@@ -1274,6 +1274,204 @@
           }
         }
       }
+    },
+    "/analytics/export/sessions": {
+      "get": {
+        "tags": [
+          "analytics"
+        ],
+        "summary": "Export Sessions",
+        "operationId": "export_sessions_analytics_export_sessions_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "csv",
+                "json"
+              ],
+              "type": "string",
+              "default": "csv",
+              "title": "Format"
+            }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "me",
+                "all"
+              ],
+              "type": "string",
+              "default": "me",
+              "title": "Scope"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Since"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Until"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/export/actions": {
+      "get": {
+        "tags": [
+          "analytics"
+        ],
+        "summary": "Export Actions",
+        "operationId": "export_actions_analytics_export_actions_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "csv",
+                "json"
+              ],
+              "type": "string",
+              "default": "csv",
+              "title": "Format"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Since"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Until"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/frontend/test/features/analytics/export_ui_test.dart
+++ b/frontend/test/features/analytics/export_ui_test.dart
@@ -1,0 +1,275 @@
+import 'dart:typed_data';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frontend/domains/auth/auth_repository.dart';
+import 'package:frontend/domains/evaluation/evaluation_repository.dart';
+import 'package:frontend/features/analytics/presentation/analytics_screen.dart';
+import 'package:frontend/features/analytics/presentation/export_controls.dart';
+import 'package:frontend/features/evaluation/presentation/debrief_screen.dart';
+import 'package:frontend/network/openapi.dart' as g;
+
+import '../../support/fake_case_response.dart';
+import '../../support/fake_communication_repository.dart';
+import '../../support/fake_export_repository.dart';
+
+g.UserResponse _user({required String role}) => g.UserResponse(
+  (b) => b
+    ..id = 'u-1'
+    ..username = 'tester'
+    ..email = 't@example.com'
+    ..role = role,
+);
+
+AuthSession _session({required String role}) => AuthSession(
+  user: _user(role: role),
+  tokens: g.TokenResponse(
+    (b) => b
+      ..accessToken = 'a'
+      ..refreshToken = 'r'
+      ..tokenType = 'bearer',
+  ),
+);
+
+g.DebriefResponse _debrief() => g.DebriefResponse(
+  (b) => b
+    ..sessionId = 'ses-1'
+    ..caseVersion = 1
+    ..totalScore = 80
+    ..scoreDiagnosis = 20
+    ..scoreDiagnostics = 20
+    ..scoreTreatment = 20
+    ..scoreSafety = 20
+    ..scoredAt = DateTime.utc(2026, 6, 1)
+    ..findings.replace(BuiltList<g.EvaluationFindingResponse>([]))
+    ..referenceSolution.replace(BuiltMap<String, JsonObject?>.of({}))
+    ..conclusions.replace(BuiltMap<String, JsonObject?>.of({})),
+);
+
+void main() {
+  testWidgets('analytics Export visible for educator', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AnalyticsScreen(
+          session: _session(role: 'educator'),
+          exportRepository: FakeExportRepository(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Export'), findsWidgets);
+    expect(find.text('Export cohort data'), findsOneWidget);
+  });
+
+  testWidgets('analytics Export visible for admin', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AnalyticsScreen(
+          session: _session(role: 'admin'),
+          exportRepository: FakeExportRepository(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Export'), findsWidgets);
+  });
+
+  testWidgets('analytics Export hidden for learner', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AnalyticsScreen(
+          session: _session(role: 'learner'),
+          exportRepository: FakeExportRepository(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Export'), findsNothing);
+    expect(
+      find.textContaining('available to educators and admins'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('export menu downloads and shows success snackbar', (
+    tester,
+  ) async {
+    final repo = FakeExportRepository();
+    String? saved;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AnalyticsExportMenuButton(
+            exportRepository: repo,
+            fileSaver:
+                ({
+                  required Uint8List bytes,
+                  required String filename,
+                  required String mimeType,
+                }) {
+                  saved = filename;
+                },
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Export'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Sessions (JSON)'));
+    await tester.pumpAndSettle();
+    expect(repo.calls, contains('sessions:json:all'));
+    expect(saved, 'sessions_cohort.json');
+    expect(find.textContaining('Downloaded'), findsOneWidget);
+  });
+
+  testWidgets('export menu shows explicit error on 403', (tester) async {
+    final repo = FakeExportRepository(
+      error: DioException(
+        requestOptions: RequestOptions(path: '/analytics/export/sessions'),
+        response: Response<List<int>>(
+          requestOptions: RequestOptions(path: '/analytics/export/sessions'),
+          statusCode: 403,
+        ),
+        type: DioExceptionType.badResponse,
+      ),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AnalyticsExportMenuButton(
+            exportRepository: repo,
+            fileSaver:
+                ({
+                  required Uint8List bytes,
+                  required String filename,
+                  required String mimeType,
+                }) {},
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Export'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Actions — this cohort (CSV)'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('permission to export'), findsOneWidget);
+  });
+
+  testWidgets('debrief shows Export actions when repository provided', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DebriefScreen(
+          caseItem: fakeCaseResponse(),
+          sessionId: 'ses-1',
+          evaluationRepository: _Eval(_debrief()),
+          communicationRepository: FakeCommunicationRepository(),
+          exportRepository: FakeExportRepository(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Export actions'), findsOneWidget);
+  });
+
+  testWidgets('debrief hides Export actions without repository', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DebriefScreen(
+          caseItem: fakeCaseResponse(),
+          sessionId: 'ses-1',
+          evaluationRepository: _Eval(_debrief()),
+          communicationRepository: FakeCommunicationRepository(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Export actions'), findsNothing);
+  });
+
+  testWidgets('session export downloads with correct filename', (tester) async {
+    final okRepo = FakeExportRepository();
+    String? saved;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SessionActionsExportButton(
+            sessionId: 'ses-9',
+            exportRepository: okRepo,
+            fileSaver:
+                ({
+                  required Uint8List bytes,
+                  required String filename,
+                  required String mimeType,
+                }) {
+                  saved = filename;
+                },
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Export actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Actions (CSV)'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(okRepo.calls, contains('session_actions:ses-9:csv'));
+    expect(saved, 'actions_session_ses-9.csv');
+    expect(find.textContaining('Downloaded'), findsOneWidget);
+  });
+
+  testWidgets('session export shows 403 toast', (tester) async {
+    final failRepo = FakeExportRepository(
+      error: DioException(
+        requestOptions: RequestOptions(path: '/analytics/export/actions'),
+        response: Response<List<int>>(
+          requestOptions: RequestOptions(path: '/analytics/export/actions'),
+          statusCode: 403,
+        ),
+        type: DioExceptionType.badResponse,
+      ),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SessionActionsExportButton(
+            sessionId: 'ses-9',
+            exportRepository: failRepo,
+            fileSaver:
+                ({
+                  required Uint8List bytes,
+                  required String filename,
+                  required String mimeType,
+                }) {},
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Export actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Actions (JSON)'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.textContaining('permission to export'), findsOneWidget);
+  });
+}
+
+class _Eval implements EvaluationRepositoryContract {
+  _Eval(this.debrief);
+  final g.DebriefResponse debrief;
+
+  @override
+  Future<g.ScoresResponse> getScores({required String sessionId}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<g.DebriefResponse> getDebrief({required String sessionId}) async =>
+      debrief;
+}

--- a/frontend/test/support/fake_export_repository.dart
+++ b/frontend/test/support/fake_export_repository.dart
@@ -1,0 +1,67 @@
+import 'dart:typed_data';
+
+import 'package:frontend/domains/analytics/export_repository.dart';
+
+class FakeExportRepository implements ExportRepositoryContract {
+  FakeExportRepository({
+    this.sessionsPayload,
+    this.cohortActionsPayload,
+    this.sessionActionsPayload,
+    this.error,
+  });
+
+  ExportPayload? sessionsPayload;
+  ExportPayload? cohortActionsPayload;
+  ExportPayload? sessionActionsPayload;
+  Object? error;
+
+  final calls = <String>[];
+
+  @override
+  Future<ExportPayload> exportSessions({
+    required ExportFormat format,
+    required String scope,
+    DateTime? since,
+    DateTime? until,
+  }) async {
+    calls.add('sessions:${format.name}:$scope');
+    if (error != null) throw error!;
+    return sessionsPayload ??
+        ExportPayload(
+          bytes: Uint8List.fromList('session,id\n'.codeUnits),
+          filename: 'sessions_cohort.${format.extension}',
+          mimeType: format.mimeType,
+        );
+  }
+
+  @override
+  Future<ExportPayload> exportCohortActions({
+    required ExportFormat format,
+    DateTime? since,
+    DateTime? until,
+  }) async {
+    calls.add('cohort_actions:${format.name}');
+    if (error != null) throw error!;
+    return cohortActionsPayload ??
+        ExportPayload(
+          bytes: Uint8List.fromList('action,id\n'.codeUnits),
+          filename: 'actions_cohort.${format.extension}',
+          mimeType: format.mimeType,
+        );
+  }
+
+  @override
+  Future<ExportPayload> exportSessionActions({
+    required String sessionId,
+    required ExportFormat format,
+  }) async {
+    calls.add('session_actions:$sessionId:${format.name}');
+    if (error != null) throw error!;
+    return sessionActionsPayload ??
+        ExportPayload(
+          bytes: Uint8List.fromList('action,id\n'.codeUnits),
+          filename: 'actions_session_$sessionId.${format.extension}',
+          mimeType: format.mimeType,
+        );
+  }
+}

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -12,6 +12,7 @@ import 'package:frontend/network/openapi.dart' as generated;
 
 import 'support/fake_case_response.dart';
 import 'support/fake_communication_repository.dart';
+import 'support/fake_export_repository.dart';
 
 void main() {
   testWidgets('CaseSimulationScreen renders with chat UI', (
@@ -44,6 +45,7 @@ void main() {
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
           communicationRepository: FakeCommunicationRepository(),
+          exportRepository: FakeExportRepository(),
         ),
       ),
     );
@@ -65,6 +67,7 @@ void main() {
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
           communicationRepository: FakeCommunicationRepository(),
+          exportRepository: FakeExportRepository(),
         ),
       ),
     );
@@ -88,6 +91,7 @@ void main() {
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
           communicationRepository: FakeCommunicationRepository(),
+          exportRepository: FakeExportRepository(),
         ),
       ),
     );
@@ -121,6 +125,7 @@ void main() {
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
           communicationRepository: FakeCommunicationRepository(),
+          exportRepository: FakeExportRepository(),
         ),
       ),
     );
@@ -152,6 +157,7 @@ void main() {
           sessionRepository: _FakeSessionRepository(),
           evaluationRepository: _FakeEvaluationRepository(),
           communicationRepository: FakeCommunicationRepository(),
+          exportRepository: FakeExportRepository(),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Closes [#94](https://github.com/virtual-ai-patient/platform/issues/94): analytics **Export** UI (CSV/JSON) for educators/admins, plus **Export actions** on the debrief screen; OpenAPI client refreshed from the [#95](https://github.com/virtual-ai-patient/platform/pull/95) backend routes.
- Fixes [#78](https://github.com/virtual-ai-patient/platform/issues/78): case-card footer no longer overflows when Evaluation is present; **Evaluation** is shown only for cases the current user has completed (avoids Access denied / “No rights”).

## Problems solved
### #94 — Export feature (frontend half of epic #13)
Educators/admins could not download analytics without `curl`. This adds:
- Analytics screen with date window + Export menu: Sessions (CSV/JSON), Actions — this cohort (CSV/JSON)
- Debrief **Export actions** (CSV/JSON) for the current session
- Role gating (cohort exports hidden for learners), loading state, and explicit 403/error toasts
- Widget tests for visibility and success/error download flows

### #78 — Incorrect case-card display
- **Start Case** was clipped off the card when Evaluation appeared → footer uses `Wrap` so actions stay in-bounds
- **Evaluation** could appear without a completed session / lead to Access denied → only wired when `GET /sessions/completed` returns a real session for that `case_id`

## Test plan
- [x] `flutter analyze` / `flutter test` (incl. `test/features/analytics/`)
- [x] Log in as educator/admin → Case library → **Analytics** → Export each menu entry; confirm download filename/extension
- [x] Log in as learner → Analytics export not offered; finish a case → debrief **Export actions** works; 403 surfaces as a toast if forced
- [x] Case library: unfinished cases have no Evaluation; finished cases show Evaluation and Start Case fully inside the card


Made with [Cursor](https://cursor.com)