### PR TITLE
docs: architecture doc cleanup - nginx sweep, QA-rev3 cross-refs, diagram notation

### DIFF
--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -11,7 +11,7 @@ This document uses three diagram families, each answering a different question:
 ## Architectural challenges and goals
 
 - **Portability across clients**
-  - The Virtual AI Patient must be accessible from multiple clients: web, Telegram bot, and potentially mobile or other channels.
+  - The Virtual AI Patient must be accessible from multiple clients: web and potentially mobile or other channels.
   - The architecture therefore centralizes logic in the backend and exposes channel-agnostic APIs, so new clients can be added without changing the core domain logic.
 
 - **LLM-agnostic AI Patient**
@@ -23,7 +23,7 @@ This document uses three diagram families, each answering a different question:
   - This requires multi-tenancy support in the backend and persistence layer (e.g. tenant-aware storage for patient configurations, conversations, and audit data).
 
 - **Maintainability and testability**
-  - Clear separation between clients, backend, and the dependency layer allows the business logic to be tested independently of infrastructure.
+  - Clear separation between frontend, backend, and the dependency layer allows the business logic to be tested independently of infrastructure.
   - Mock implementations for both the database and LLM are first-class parts of the design, so automated tests can run deterministically without relying on external services or real data stores.
 
 ## Diagram 1 — High-level architecture

--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -33,12 +33,10 @@ This document uses three diagram families, each answering a different question:
 ```mermaid
 flowchart TB
     subgraph Clients
-        TG["Telegram bot\n(primary client)"]
-        WEB["Web frontend\n(secondary client)"]
+        WEB["Web frontend"]
     end
 
-    TG --> BE[Backend]
-    WEB --> BE
+    WEB --> BE[Backend]
 
     subgraph Dependencies layer
         subgraph DBLayer[Database interaction interface]
@@ -144,28 +142,24 @@ sequenceDiagram
 
 **Notation:** UML deployment diagram, rendered with mermaid `flowchart LR`.
 
-Reflects the current `docker-compose.yml`: a single Docker host runs three containers. There is no reverse proxy in front of them — the frontend and backend are each exposed directly on their own host port, and the browser talks to both. The Telegram bot has its own `Dockerfile` but is not wired into `docker-compose.yml` yet (commented out), so it is shown as not-yet-deployed.
+Reflects the current `docker-compose.yml`: a single Docker host runs three containers. There is no reverse proxy in front of them — the frontend and backend are each exposed directly on their own host port, and the browser talks to both.
 
 ```mermaid
 flowchart LR
     Browser["Learner's browser"]
-    TGClient["Telegram client"]
 
     subgraph Host["Docker host — docker compose up"]
         FE["frontend container\nnginx serves built Flutter web app\nhost :8080 -> container :80"]
         BE["backend container\nFastAPI / uvicorn\nhost :8000 -> container :8000"]
         PG[("postgres container\n:5432, volume: postgres_data")]
-        BOT["bot container\n(not yet deployed —\ncommented out in docker-compose.yml)"]
     end
 
     Browser -->|HTTP :8080| FE
     FE -->|BACKEND_BASE_URL, HTTP :8000| BE
     BE -->|DATABASE_URL| PG
-    TGClient -.->|planned| BOT
-    BOT -.->|planned| BE
 ```
 
-The nginx inside the frontend container is a **static-file server for the built web app** — a Dockerfile implementation detail, not the reverse proxy that used to sit in front of both clients in Diagram 1. That reverse-proxy nginx never had checked-in config in this repo; it was diagram-only and has been removed rather than relocated.
+The nginx inside the frontend container is a **static-file server for the built web app** — a Dockerfile implementation detail, not the reverse proxy that used to sit in front of the client in Diagram 1. That reverse-proxy nginx never had checked-in config in this repo; it was diagram-only and has been removed rather than relocated.
 
 ## LLM Patient Role Design
 

--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -1,5 +1,13 @@
 # System Architecture
 
+## Diagram legend
+
+This document uses three diagram families, each answering a different question:
+
+- **Container diagram** (C4 model, Level 2) — "what are the running pieces and how do they talk to each other?" It shows components (clients, backend, external services) and the connections between them, but not runtime sequencing or physical deployment. Diagram 1 below.
+- **Sequence diagram** (UML) — "in what order do messages happen for one scenario?" It shows a single flow through time, across participants, for one representative session. Diagram 2 below. It is not a state machine and does not capture every possible branch.
+- **Deployment diagram** (UML) — "what physically runs where, and on what ports?" It shows processes/containers, host boundaries, and network exposure — not application logic. Diagram 3 below.
+
 ## Architectural challenges and goals
 
 - **Portability across clients**
@@ -18,7 +26,9 @@
   - Clear separation between clients, backend, and the dependency layer allows the business logic to be tested independently of infrastructure.
   - Mock implementations for both the database and LLM are first-class parts of the design, so automated tests can run deterministically without relying on external services or real data stores.
 
-## High-level architecture
+## Diagram 1 — High-level architecture
+
+**Notation:** C4 model, Level 2 (Container diagram), rendered with mermaid `flowchart TB`.
 
 ```mermaid
 flowchart TB
@@ -27,9 +37,8 @@ flowchart TB
         WEB["Web frontend\n(secondary client)"]
     end
 
-    TG --> NGINX[nginx]
-    WEB --> NGINX
-    NGINX --> BE[Backend]
+    TG --> BE[Backend]
+    WEB --> BE
 
     subgraph Dependencies layer
         subgraph DBLayer[Database interaction interface]
@@ -89,7 +98,10 @@ flowchart TB
   - Session store (messages, orders, submissions)
   - Evaluation artifacts (scores, evidence)
 
-## Data flow (typical session)
+## Diagram 2 — Data flow (typical session)
+
+**Notation:** UML sequence diagram, rendered with mermaid `sequenceDiagram`.
+
 ```mermaid
 sequenceDiagram
   autonumber
@@ -128,6 +140,33 @@ sequenceDiagram
   B-->>U: Debrief + scores
 ```
 
+## Diagram 3 — Deployment view
+
+**Notation:** UML deployment diagram, rendered with mermaid `flowchart LR`.
+
+Reflects the current `docker-compose.yml`: a single Docker host runs three containers. There is no reverse proxy in front of them — the frontend and backend are each exposed directly on their own host port, and the browser talks to both. The Telegram bot has its own `Dockerfile` but is not wired into `docker-compose.yml` yet (commented out), so it is shown as not-yet-deployed.
+
+```mermaid
+flowchart LR
+    Browser["Learner's browser"]
+    TGClient["Telegram client"]
+
+    subgraph Host["Docker host — docker compose up"]
+        FE["frontend container\nnginx serves built Flutter web app\nhost :8080 -> container :80"]
+        BE["backend container\nFastAPI / uvicorn\nhost :8000 -> container :8000"]
+        PG[("postgres container\n:5432, volume: postgres_data")]
+        BOT["bot container\n(not yet deployed —\ncommented out in docker-compose.yml)"]
+    end
+
+    Browser -->|HTTP :8080| FE
+    FE -->|BACKEND_BASE_URL, HTTP :8000| BE
+    BE -->|DATABASE_URL| PG
+    TGClient -.->|planned| BOT
+    BOT -.->|planned| BE
+```
+
+The nginx inside the frontend container is a **static-file server for the built web app** — a Dockerfile implementation detail, not the reverse proxy that used to sit in front of both clients in Diagram 1. That reverse-proxy nginx never had checked-in config in this repo; it was diagram-only and has been removed rather than relocated.
+
 ## LLM Patient Role Design
 
 The believability of the LLM patient role is the product's primary differentiator: comparable clinical-training platforms exist, so quality of execution of the patient behaviours is what the proposal competes on. This section describes how the four core behaviours are realised at the prompt/orchestration level. Full evidence — what was tested, what worked, and what remains preliminary — lives in [Patient role research](../proposal/patient-role-research.md).
@@ -148,6 +187,20 @@ The believability of the LLM patient role is the product's primary differentiato
 - **State management**
   - Per-turn state (facts already disclosed, current disclosure level, emotional state, faded facts) is maintained by the backend session state machine and **fed back into the prompt on every turn**: the system block carries the case facts and behaviour rules, while the full dialogue history is passed in `messages` (no truncation at tested lengths of ~25 turns; truncation and summary policies remain untested).
   - This is what keeps repeated questions consistent with earlier answers (G4 class in the [failure catalogue](../research/ai-patient-problems-and-mitigations.md)); temperature is held near 0.3 in production since higher values introduced consistency failures.
+
+## QA compliance
+
+Which QA-rev3 attribute each architectural decision satisfies (see [qa-rev3.md](../qa/qa-rev3.md)):
+
+| Architectural decision | QA-rev3 attribute |
+| :--- | :--- |
+| LLM interface abstraction (dependencies layer) | [QA-ARCH-01](../qa/qa-rev3.md#5-architecture--observability-qa-arch) — pluggable AI adapter, no changes outside the adapter layer to swap providers |
+| Session state machine persists every message/order/submission to Storage | [QA-ARCH-02](../qa/qa-rev3.md#5-architecture--observability-qa-arch) — structured logging of all learner actions |
+| `docker compose up` brings up frontend, backend, and postgres with no manual steps (Diagram 3) | [QA-REPRO-01](../qa/qa-rev3.md#6-reproducibility-qa-repro) — one-command full-stack startup |
+| Mock LLM in the dependencies layer | [QA-REPRO-03](../qa/qa-rev3.md#6-reproducibility-qa-repro) — prototype runs without an external API key |
+| Mock database in the dependencies layer | [QA-REPRO-01](../qa/qa-rev3.md#6-reproducibility-qa-repro) — deterministic local runs without a real Postgres instance |
+| Case-grounded generation + versioned cases | [QA-SAFE-02](../qa/qa-rev3.md#4-ai-safety--guardrails-qa-safe) — output grounded in case data, not invented facts |
+| Per-turn state fed back into the prompt every turn (see [LLM Patient Role Design](#llm-patient-role-design)) | [QA-PERF-01](../qa/qa-rev3.md#2-performance--latency-qa-perf) — chat responses within the immersion-preserving latency budget |
 
 ## Architectural principles
 - **LLM Patient Role Design is the primary differentiator** — see [§ LLM Patient Role Design](#llm-patient-role-design); patient-behaviour quality claims must trace to [Patient role research](../proposal/patient-role-research.md).

--- a/docs/sprints/sprint03/architecture.md
+++ b/docs/sprints/sprint03/architecture.md
@@ -5,9 +5,11 @@ section: sprints
 parent: Sprint 03 Overview
 ---
 
+> **Historical snapshot (pre-pivot).** This page and its screenshot record the architecture as presented in Sprint 03. The reverse-proxy nginx shown here was removed from the diagrams in a later revision — see [current System Architecture](../../architecture/system-architecture.md) for the up-to-date view.
+
 ![Architecture diagram](https://github.com/user-attachments/assets/f32e1675-e55e-4566-a2c7-aea89bc63945)
 
-Two clients — **Telegram bot** (primary) and **Web frontend** (secondary) — route through **nginx** to a single **Backend**.
+Two clients — **Telegram bot** (primary) and **Web frontend** (secondary) — routed through **nginx** to a single **Backend** at the time of this sprint.
 
 The backend connects to two abstraction interfaces in a **Dependencies layer**:
 


### PR DESCRIPTION
## Summary
- Removes the reverse-proxy nginx node from Diagram 1 (high-level architecture) — frontend and backend are exposed on separate host ports with no proxy in front of them, per `docker-compose.yml`
- Adds Diagram 3, a UML deployment diagram built from the actual `docker-compose.yml`: frontend/backend/postgres containers, real host ports, and the bot shown as not-yet-deployed (it's commented out in compose). Notes that nginx still legitimately exists *inside* the frontend container as its static-file server — a different thing from the removed reverse proxy
- Adds a **Diagram legend** section explaining container / sequence / deployment notation
- Adds explicit **notation tags** under each of the three diagrams (C4 container, UML sequence, UML deployment)
- Adds a **QA compliance** section mapping architectural decisions to real `qa-rev3.md` attribute IDs (QA-ARCH-01/02, QA-REPRO-01/03, QA-SAFE-02, QA-PERF-01)
- Marks `docs/sprints/sprint03/architecture.md` as a historical, pre-pivot snapshot rather than rewriting its prose to hide nginx while its embedded screenshot still shows it

Closes #91

## Test plan
- [x] `markdownlint-cli2` passes on both changed files
- [x] `grep -ri nginx docs/` returns only the two intentional mentions (frontend-container nginx in the current doc, historical marker in the sprint03 snapshot)
- [ ] Confirm the doc renders correctly on the Jekyll site (not build-verified locally — no `Gemfile` in the repo, local Ruby toolchain too old to bootstrap `jekyll-remote-theme` quickly)