### PR TITLE
docs(#92): restructure site nav into Current/Historical buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,7 @@ yarn-error.log*
 # Cursor / editor-specific indices
 .cursorignore
 .cursorindexingignore
-.claude/
+.claude/docs/vendor/
+docs/.bundle/
+docs/_site/
+docs/vendor/

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "just-the-docs", "~> 0.10"
+gem "jekyll-remote-theme"
+gem "jekyll-include-cache"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,183 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.8)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.35.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    http_parser.rb (0.8.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-remote-theme (0.5.1)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, < 4.0, != 2.0.0)
+      openssl (>= 3.1.2)
+      rubyzip (>= 1.3.0, < 3.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.9.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.21.1)
+    just-the-docs (0.12.0)
+      jekyll (>= 3.8.5)
+      jekyll-include-cache
+      jekyll-seo-tag (>= 2.0)
+      rake (>= 12.3.1)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    openssl (4.0.2)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (7.0.5)
+    rake (13.4.2)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
+    rubyzip (2.4.1)
+    safe_yaml (1.0.5)
+    sass-embedded (1.102.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.102.0-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.102.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+  jekyll-include-cache
+  jekyll-remote-theme
+  just-the-docs (~> 0.10)
+
+BUNDLED WITH
+   2.6.9

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,6 +11,10 @@ baseurl: "/platform"
 color_scheme: light
 
 nav_enabled: true
+
+mermaid:
+  version: "11"
+
 aux_links:
   "GitHub repository":
     - "https://github.com/virtual-ai-patient/platform"

--- a/docs/about-the-pivot.md
+++ b/docs/about-the-pivot.md
@@ -1,0 +1,37 @@
+---
+layout: default
+title: About the Pivot
+parent: Current — Startup Proposal
+nav_order: 1
+---
+
+# About the Pivot
+
+## What changed
+
+The project started with the goal of delivering a clinical training platform to an industry partner, Third Opinion. By early March 2026 it became clear that the engagement would not progress to a signed agreement. Rather than pause, the team redefined the goal:
+
+**Old goal:** deliver a working product to a paying customer by July 2026.
+
+**New goal:** deliver a validated startup proposal — a pitch backed by a working prototype and real evidence that the core hypotheses hold.
+
+## What the pivot means in practice
+
+| Before | After |
+| :--- | :--- |
+| Build for 300+ concurrent hospital users | Build for expert sessions and corridor tests |
+| Ship features from an epic-driven roadmap | Validate three hypotheses with prototype iterations |
+| QA targets: scalability, uptime, SAST | QA targets: reproducibility, hypothesis exit criteria |
+| Definition of Done: code passes AC | Definition of Done: code done **and** hypothesis advanced |
+| Feedback source: industry partner | Feedback source: domain experts, corridor-test participants |
+
+## Where to find the evidence
+
+- [Hypotheses](proposal/hypotheses.md) — H1, H2, H3 with validation criteria and current status
+- [User Insights](proposal/user-insights.md) — L2 artifacts: expert sessions P-01 and P-02
+- [Strategic Planning Rev 2](project%20management/strategic-planning-rev2.md) — the post-pivot roadmap
+- [QA Rev 3](qa/qa-rev3.md) and [QA Rev 4](qa/qa-rev4.md) — revised quality attributes
+
+## Historical documents
+
+The pre-pivot documents are preserved under [Historical — Product for Customer](historical.md). They show what the project was building toward before the pivot and are kept for traceability. Do not cite them as the current plan.

--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: System Architecture
+parent: Current — Startup Proposal
+nav_order: 2
+mermaid: true
+---
+
 # System Architecture
 
 ## Diagram legend

--- a/docs/cicd/index.md
+++ b/docs/cicd/index.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: CI/CD
-nav_order: 3
+parent: Current — Startup Proposal
+nav_order: 6
 has_children: true
 ---
 

--- a/docs/cicd/pipeline.md
+++ b/docs/cicd/pipeline.md
@@ -2,6 +2,7 @@
 layout: default
 title: Pipeline
 parent: CI/CD
+grand_parent: Current — Startup Proposal
 nav_order: 1
 ---
 

--- a/docs/cm/configuration-management-rev2.md
+++ b/docs/cm/configuration-management-rev2.md
@@ -1,5 +1,7 @@
 # Configuration Management — Revision 2 (post-pivot: startup proposal)
 
+> **[RETROSPECTIVE — Written July 2026]** This document describes the CM hierarchy and traceability policy as we believe it *should have been* defined from the start of the pivot. In practice the project did not operate by this framework from day one — this is our honest reconstruction of the correct approach, written for the startup proposal. See [About the Pivot](../about-the-pivot.md).
+
 ## 1. Artifact Hierarchy
 
 Every artifact in the repository traces back to the project goal through a five-level chain. No GitHub Issue may exist without a reference to a Level 2 or Level 3 artifact.

--- a/docs/cm/configuration-management.md
+++ b/docs/cm/configuration-management.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Configuration Management
+parent: Current — Startup Proposal
+nav_order: 5
+---
+
 # Configuration Management — History
 
 This document tracks the evolution of the CM & Traceability Policy.

--- a/docs/current.md
+++ b/docs/current.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Current — Startup Proposal
+nav_order: 2
+has_children: true
+---
+
+# Current — Startup Proposal
+
+Documents in this section describe the project as it stands **after the pivot** (March 2026). The goal is a validated startup proposal backed by a working prototype. Every document here is the actively maintained version.
+
+See [About the Pivot](about-the-pivot.md) for the full context.

--- a/docs/historical.md
+++ b/docs/historical.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Historical — Product for Customer
+nav_order: 3
+has_children: true
+---
+
+# Historical — Product for Customer
+
+Documents in this section were written when the project goal was to deliver a medical training product to an industry partner (Third Opinion). The engagement did not progress to a signed agreement.
+
+These documents are kept for traceability and to show the before/after of the pivot. **Do not cite them as current.** For the current plan, see [Current — Startup Proposal](current.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,50 @@
 ---
-title: Virtual AI Patient
 layout: default
+title: Virtual AI Patient
 nav_order: 1
 ---
 
 # Virtual AI Patient — Documentation
 
-Welcome to the documentation site for the Virtual AI Patient project.
+This project started as a clinical training platform for an industry partner. In March 2026, after the partner engagement ended, the goal shifted to a **validated startup proposal** backed by a working prototype. Both phases of the project are documented here.
 
-- Product overview and positioning
-- System architecture and technical specification
-- Clinical case data format
-- Integration notes for partner platforms
+See [About the Pivot](about-the-pivot.md) for the full story.
 
-Use the navigation on the left to explore individual documents. The raw Markdown sources live in this `docs/` folder and are rendered with the [Just the Docs theme](https://github.com/just-the-docs/just-the-docs).
+---
 
+## Current — Startup Proposal
+
+Documents that describe the project as it stands today.
+
+| Document | What it contains |
+| :--- | :--- |
+| [About the Pivot](about-the-pivot.md) | Why and how the goal changed |
+| [System Architecture](architecture/system-architecture.md) | Component, sequence, and deployment diagrams |
+| [Hypotheses](proposal/hypotheses.md) | H1, H2, H3 — what we are testing and current evidence |
+| [User Insights](proposal/user-insights.md) | Expert sessions P-01 and P-02 |
+| [Patient Role Research](proposal/patient-role-research.md) | Automated multi-model LLM evaluation |
+| [QA Rev 3](qa/qa-rev3.md) | Quality attributes after pivot (reproducibility, docs) |
+| [QA Rev 4](qa/qa-rev4.md) | Hypothesis-validation exit criteria (QA-VAL) |
+| [Configuration Management Rev 2](cm/configuration-management-rev2.md) | L1–L5 hypothesis-driven hierarchy |
+| [Strategic Planning Rev 2](project%20management/strategic-planning-rev2.md) | Discovery → P1/P2/P3 → Proposal Finalisation |
+| [Tactical Planning Rev 2](project%20management/tactical-planning-rev2.md) | Two-week hypothesis-driven sprint cycle |
+| [CI/CD Pipeline](cicd/pipeline.md) | Demo-stability pipeline and prototype tagging |
+| [Product Description](product/technical-product-description.md) | What the product is and who it is for |
+
+---
+
+## Historical — Product for Customer
+
+Documents from the phase when the goal was to deliver a product to Third Opinion.
+Kept for traceability — **do not cite as current**.
+
+| Document | What it contains |
+| :--- | :--- |
+| [Market Assessment](market/market-assessment.md) | Market sizing and competitive landscape |
+| [Technical Specification](spec/technical-specification.md) | Full-featured product spec with QA metrics |
+| [Integration Overview](integrations/integration-overview.md) | Partner platform integration plan |
+| [QA Rev 1](qa/qa-rev1.md) · [QA Rev 2](qa/qa-rev2.md) | Original scalability and security thresholds |
+| [Strategic Planning Rev 1](project%20management/strategic-planning-rev1.md) | 5-month epic-driven roadmap |
+| [Tactical Planning Rev 1](project%20management/tactical-planning-rev1.md) | Denis-feedback weekly cycle |
+| [Configuration Management Rev 1](cm/configuration-management-rev1.md) | 6-level product-delivery hierarchy |
+| [Sprints](sprints/index.md) | Sprint overviews and transcriptions |

--- a/docs/integrations/integration-overview.md
+++ b/docs/integrations/integration-overview.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: Integration Overview
+parent: Historical — Product for Customer
+nav_order: 3
+---
+
+> **[HISTORICAL — Pre-pivot]** Written when the project goal was to deliver a product to an industry partner. Kept for traceability. See [Current — Startup Proposal](../current.md) for the active documents.
+
 # Integration Overview — Pilot on a Physician Platform
 
 This document describes the intended integration points for embedding Virtual AI Patient into an existing physician platform during the pilot.

--- a/docs/market/market-assessment.md
+++ b/docs/market/market-assessment.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: Market Assessment
+parent: Historical — Product for Customer
+nav_order: 1
+---
+
+> **[HISTORICAL — Pre-pivot]** Written when the project goal was to deliver a product to an industry partner. Kept for traceability. See [Current — Startup Proposal](../current.md) for the active documents.
+
 # Market Assessment — Virtual AI Patient
 
 ## 1. Problem and why now

--- a/docs/product/technical-product-description.md
+++ b/docs/product/technical-product-description.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Product Description
+parent: Current — Startup Proposal
+nav_order: 7
+---
+
 # Technical Product Description — Virtual AI Patient
 
 ## 1. Problem statement

--- a/docs/project management/strategic-planning-rev2.md
+++ b/docs/project management/strategic-planning-rev2.md
@@ -1,5 +1,7 @@
 # Strategic Planning — Revision 2 (post-pivot: startup proposal)
 
+> **[RETROSPECTIVE — Written July 2026]** This document describes the strategic plan as we believe it *should have been* defined from the start of the pivot in March 2026. In practice the project did not follow this framework from day one — this is our honest reconstruction of the correct approach, written for the startup proposal. See [About the Pivot](../about-the-pivot.md).
+
 ---
 
 ## 1. What is Strategic Planning?

--- a/docs/project management/strategic-planning.md
+++ b/docs/project management/strategic-planning.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Strategic Planning
+parent: Current — Startup Proposal
+nav_order: 8
+---
+
 # Strategic Planning — History
 
 This document tracks the evolution of the project's strategic plan.

--- a/docs/project management/tactical-planning-rev2.md
+++ b/docs/project management/tactical-planning-rev2.md
@@ -1,5 +1,7 @@
 # Tactical Planning — Rev 2
 
+> **[RETROSPECTIVE — Written July 2026]** This document describes the tactical process as we believe it *should have been* run from the start of the pivot. In practice the team did not operate by this cycle initially — this is our honest reconstruction of the correct approach, written for the startup proposal. See [About the Pivot](../about-the-pivot.md).
+
 **Goal:** Deliver a startup proposal backed by a validated prototype.
 **Active since:** March 2026 (pivot)
 **Traceability:** [strategic-planning-rev2.md](strategic-planning-rev2.md) · [hypotheses.md](../proposal/hypotheses.md) · [configuration-management-rev2.md](../cm/configuration-management-rev2.md)

--- a/docs/project management/tactical-planning.md
+++ b/docs/project management/tactical-planning.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Tactical Planning
+parent: Current — Startup Proposal
+nav_order: 9
+---
+
 # Tactical Planning — History
 
 This page is the history index for the Tactical Planning practice area.

--- a/docs/proposal/hypotheses.md
+++ b/docs/proposal/hypotheses.md
@@ -1,6 +1,8 @@
 ---
+layout: default
 title: Hypotheses
 parent: Proposal
+grand_parent: Current — Startup Proposal
 nav_order: 2
 ---
 

--- a/docs/proposal/index.md
+++ b/docs/proposal/index.md
@@ -1,6 +1,8 @@
 ---
+layout: default
 title: Proposal
-nav_order: 2
+parent: Current — Startup Proposal
+nav_order: 3
 has_children: true
 ---
 

--- a/docs/proposal/patient-role-research.md
+++ b/docs/proposal/patient-role-research.md
@@ -1,6 +1,8 @@
 ---
+layout: default
 title: Patient role research
 parent: Proposal
+grand_parent: Current — Startup Proposal
 nav_order: 4
 ---
 

--- a/docs/proposal/user-insights.md
+++ b/docs/proposal/user-insights.md
@@ -1,6 +1,8 @@
 ---
+layout: default
 title: User insights
 parent: Proposal
+grand_parent: Current — Startup Proposal
 nav_order: 3
 ---
 

--- a/docs/qa/index.md
+++ b/docs/qa/index.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: QA
-nav_order: 1
+parent: Current — Startup Proposal
+nav_order: 4
 has_children: true
 ---
 

--- a/docs/qa/qa-rev1.md
+++ b/docs/qa/qa-rev1.md
@@ -2,6 +2,7 @@
 layout: default
 title: QA Revision 1
 parent: QA
+grand_parent: Current — Startup Proposal
 nav_order: 1
 ---
 

--- a/docs/qa/qa-rev2.md
+++ b/docs/qa/qa-rev2.md
@@ -2,6 +2,7 @@
 layout: default
 title: QA Revision 2
 parent: QA
+grand_parent: Current — Startup Proposal
 nav_order: 2
 ---
 

--- a/docs/qa/qa-rev3.md
+++ b/docs/qa/qa-rev3.md
@@ -2,12 +2,15 @@
 layout: default
 title: QA Revision 3
 parent: QA
+grand_parent: Current — Startup Proposal
 nav_order: 3
 ---
 
 # Quality Attributes (QA) — Virtual AI Patient
 **Document Version:** 3.0 (Revision 3)
 **URL:** [Here](https://virtual-ai-patient.github.io/platform/qa/qa-rev3)
+
+> **[RETROSPECTIVE — Written July 2026]** This revision was written as part of the startup proposal preparation. It describes the quality attributes as they *should have been* defined at the time of the pivot in March 2026. In practice these constraints were not formally documented from day one of the pivot. See [About the Pivot](../about-the-pivot.md).
 
 ## 1. Overview
 

--- a/docs/qa/qa-rev4.md
+++ b/docs/qa/qa-rev4.md
@@ -2,12 +2,15 @@
 layout: default
 title: QA Revision 4
 parent: QA
+grand_parent: Current — Startup Proposal
 nav_order: 4
 ---
 
 # Quality Attributes (QA) — Virtual AI Patient
 **Document Version:** 4.0 (Revision 4)
 **URL:** [Here](https://virtual-ai-patient.github.io/platform/qa/qa-rev4)
+
+> **[RETROSPECTIVE — Written July 2026]** This revision was written to capture hypothesis-validation exit criteria after expert sessions P-01 and P-02. It describes the quality attributes as they *should have been* formalised upon receiving that evidence. See [About the Pivot](../about-the-pivot.md).
 
 ## 1. Overview
 

--- a/docs/spec/technical-specification.md
+++ b/docs/spec/technical-specification.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: Technical Specification
+parent: Historical — Product for Customer
+nav_order: 2
+---
+
+> **[HISTORICAL — Pre-pivot]** Written when the project goal was to deliver a product to an industry partner. Kept for traceability. See [Current — Startup Proposal](../current.md) for the active documents.
+
 # Technical Specification (with Quality Metrics) — Virtual AI Patient
 
 ## 0. Scope and goals

--- a/docs/sprints/index.md
+++ b/docs/sprints/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Sprints
+parent: Historical — Product for Customer
+nav_order: 4
 has_children: true
-nav_order: 10
 ---

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "Virtual AI Patient — documentation dev shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            ruby_3_4
+            gcc
+            gnumake
+            zlib
+            libffi
+            openssl
+            pkg-config
+          ];
+
+          shellHook = ''
+            export BUNDLE_PATH="$PWD/docs/vendor/bundle"
+            export GEM_HOME="$PWD/docs/vendor/bundle"
+            cd docs
+            bundle config set --local path 'vendor/bundle'
+            bundle install --quiet
+            echo ""
+            echo "Docs dev shell ready. Commands:"
+            echo "  bundle exec jekyll serve --livereload   # live-reload dev server"
+            echo "  bundle exec jekyll build                # one-shot build to _site/"
+            echo ""
+            echo "Site will be at: http://localhost:4000/platform/"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Split the Jekyll docs site into two top-level nav sections:
- Current — Startup Proposal: everything written post-pivot
- Historical — Product for Customer: pre-pivot artefacts (kept for traceability, clearly labelled, not deleted)

Changes:
- Add docs/current.md and docs/historical.md as nav bucket pages
- Add docs/about-the-pivot.md explaining the goal change with a before/after table and links to both sections
- Rewrite docs/index.md as a structured landing page with two tables
- Add frontmatter (layout/parent/nav_order) to 25 files that were missing it and therefore invisible in the sidebar nav
- Add grand_parent to QA, Proposal, and CI/CD children for 3-level nav
- Wire Sprints under Historical; all current practice-area docs under Current
- Add retrospective disclaimer to rev2 planning/QA/CM docs: "written July 2026 as how it should have been, not a log of actual practice"
- Add historical banner to market-assessment, technical-specification, and integration-overview
- Enable Mermaid rendering: add mermaid config to _config.yml and mermaid: true to system-architecture.md frontmatter
- Add docs/Gemfile for local Jekyll with just-the-docs 0.10
- Add flake.nix devshell (ruby_3_4, bundler, openssl) for nix develop
- Add docs/_site/ and docs/vendor/ to .gitignore

Closes #92