### PR TITLE
docs: fix orphaned nav items — assign parent to all remaining pages

### DIFF
--- a/docs/.markdownlint-cli2.jsonc
+++ b/docs/.markdownlint-cli2.jsonc
@@ -1,4 +1,12 @@
 {
+  "ignores": [
+    "project management/epic-analytics-export/**",
+    "project management/epic-rest-api/**",
+    "project management/epic-safety/**",
+    "project management/feature-communication-evaluation/**",
+    "project management/feature-persistent-sessions/**",
+    "project management/pivot-startup-proposal/**"
+  ],
   "config": {
     "default": true,
     "MD012": false,

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,3 +18,15 @@ mermaid:
 aux_links:
   "GitHub repository":
     - "https://github.com/virtual-ai-patient/platform"
+
+exclude:
+  - README.md
+  - Gemfile
+  - Gemfile.lock
+  - vendor
+  - "project management/epic-analytics-export"
+  - "project management/epic-rest-api"
+  - "project management/epic-safety"
+  - "project management/feature-communication-evaluation"
+  - "project management/feature-persistent-sessions"
+  - "project management/pivot-startup-proposal"

--- a/docs/cases/case001-acute-mi.md
+++ b/docs/cases/case001-acute-mi.md
@@ -1,3 +1,8 @@
+---
+layout: default
+nav_exclude: true
+---
+
 # Clinical Case – CASE-001: Acute Chest Pain (Suspected Myocardial Infarction)
 
 - **Case ID:** `CASE-001`

--- a/docs/cases/case002-migraine.md
+++ b/docs/cases/case002-migraine.md
@@ -1,3 +1,8 @@
+---
+layout: default
+nav_exclude: true
+---
+
 # Clinical Case – CASE-002: Severe Headache (Migraine with Aura)
 
 - **Case ID:** `CASE-002`

--- a/docs/cases/case003-pneumonia.md
+++ b/docs/cases/case003-pneumonia.md
@@ -1,3 +1,8 @@
+---
+layout: default
+nav_exclude: true
+---
+
 # Clinical Case – CASE-003: Productive Cough and Fever (Community‑Acquired Pneumonia)
 
 - **Case ID:** `CASE-003`

--- a/docs/cm/configuration-management-rev1.md
+++ b/docs/cm/configuration-management-rev1.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: CM — Rev 1 (Historical)
+parent: Configuration Management
+grand_parent: Current — Startup Proposal
+nav_order: 1
+---
 
 # Configuration Management — Revision 1 (pre-pivot)
 

--- a/docs/cm/configuration-management-rev2.md
+++ b/docs/cm/configuration-management-rev2.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: CM — Rev 2 (Current)
+parent: Configuration Management
+grand_parent: Current — Startup Proposal
+nav_order: 2
+---
+
 # Configuration Management — Revision 2 (post-pivot: startup proposal)
 
 > **[RETROSPECTIVE — Written July 2026]** This document describes the CM hierarchy and traceability policy as we believe it *should have been* defined from the start of the pivot. In practice the project did not operate by this framework from day one — this is our honest reconstruction of the correct approach, written for the startup proposal. See [About the Pivot](../about-the-pivot.md).

--- a/docs/data/clinical-case-format.md
+++ b/docs/data/clinical-case-format.md
@@ -1,3 +1,8 @@
+---
+layout: default
+nav_exclude: true
+---
+
 # Clinical Case Data Format — MVP
 
 This document defines a **minimal, scalable** schema for clinical cases and the “gold standard” required for evaluation.

--- a/docs/project management/epic-analytics-export/task-01-backend-analytics-and-actions-export.md
+++ b/docs/project management/epic-analytics-export/task-01-backend-analytics-and-actions-export.md
@@ -1,0 +1,36 @@
+Parent epic: [#13 — Analytics and Observability](https://github.com/virtual-ai-patient/platform/issues/13).
+
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+Epic #13 is closed on every acceptance criterion except **"Export functionality for analytics data (CSV/JSON)"** and the related **"Export feature working"** line in the Definition of Done. This enabler delivers exactly that: a backend API that streams both the aggregated analytics view and the raw learner-action trace (the `action_logs` records) as CSV or JSON, so an educator can download a snapshot of a cohort and a researcher can inspect the full action stream behind it.
+
+*   **[QA-ARCH-02 (Structured action trace)](https://virtual-ai-patient.github.io/platform/qa/qa-rev3#8-architecture--observability-qa-arch):** Export reads from the `action_logs` table, which is already the single source of truth for learner actions — this enabler exposes it, does not duplicate it.
+*   **[QA-SEC-01 (RBAC)](https://virtual-ai-patient.github.io/platform/qa/qa-rev3#4-security--privacy-qa-sec):** Only `educator` and `admin` roles can export cohort data; a `learner` can export only their own actions.
+*   **[QA-REPRO-04 (1–5 concurrent demo sessions)](https://virtual-ai-patient.github.io/platform/qa/qa-rev3#6-reproducibility-qa-repro-new):** Export is expected to run on demo-sized datasets (single-host, low concurrency) — streaming is used for correctness, not for throughput at scale.
+*   **[QA-REL-02 (Deterministic output)](https://virtual-ai-patient.github.io/platform/qa/qa-rev3#3-reliability--data-integrity-qa-rel):** Two exports over the same time window yield byte-identical CSV output (stable column order, stable row order).
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **Endpoints:**
+    *   `GET /v1/analytics/export/sessions?since=&until=&scope=me|cohort:{id}&format=csv|json` — flat row-per-session export (score summary + finding counts). Extends the export slot from the earlier REST-API analytics task.
+    *   `GET /v1/analytics/export/actions?session_id=&format=csv|json` — full learner-action stream for a single session (chronological `action_logs` rows: chat turns, test orders, submissions).
+    *   `GET /v1/analytics/export/actions?cohort_id=&since=&until=&format=csv|json` — same shape, aggregated across a cohort (educator/admin only).
+2.  **Data schema (rows):**
+    *   **SessionExportRow:** `session_id`, `case_id`, `case_version`, `learner_id`, `started_at`, `finished_at`, `total_score`, per-subscore fields, `findings_by_severity`.
+    *   **ActionExportRow:** `session_id`, `learner_id`, `turn_index`, `timestamp`, `action_type` (`chat_user | chat_assistant | order_test | submit_ddx | submit_diagnosis | submit_plan | save_conclusions`), `payload_json` (the structured action body — never a redacted blob).
+3.  **Streaming + safety:** All three endpoints use FastAPI `StreamingResponse` driven by an async generator over paginated repository reads — no full materialisation of the result set. CSV writer follows RFC-4180 and prefixes any cell starting with `=`, `+`, `-`, `@` with a single quote to prevent spreadsheet injection.
+4.  **Repository additions (`backend/analytics/repository.py`):** `iter_session_rows(scope, since, until)` and `iter_action_rows(session_id | cohort_id, since, until)`. Both take an explicit `order_by` so exports are stable.
+5.  **Quality compliance:** **Python 3.14** with **MyPy --strict**; endpoints appear in Swagger UI with example rows; integration tests in `backend/tests/test_export.py` cover CSV + JSON, learner/educator/admin auth outcomes, empty-window edge case, and determinism (two calls → identical bytes).
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] All three endpoints reachable under `/v1/analytics/export/...` and visible in Swagger UI with example responses.
+*   [ ] Sessions export and per-session actions export round-trip cleanly through Python's `csv` reader; spreadsheet-injection-prone leading characters are neutralised.
+*   [ ] Authorisation enforced: learner exporting another learner's actions gets 403; learner can export their own; educator/admin can export cohort scope.
+*   [ ] Two exports over the same window produce byte-identical CSV output (verified by a determinism test).
+*   [ ] Export streams a 5 000-row fixture without memory growing linearly in row count (verified by a benchmark test).
+*   [ ] Epic #13's "Export functionality for analytics data (CSV/JSON)" acceptance criterion is checked off in that epic when this task closes.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/epic-analytics-export/task-02-frontend-export-ui.md
+++ b/docs/project management/epic-analytics-export/task-02-frontend-export-ui.md
@@ -1,0 +1,33 @@
+Parent epic: [#13 — Analytics and Observability](https://github.com/virtual-ai-patient/platform/issues/13).
+
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+Even with the backend export endpoints in place, an educator or researcher cannot get data out of the system without a UI trigger — copying `curl` commands is not an option for a corridor-test demo. This enabler adds an **Export** action on the analytics screen and on the per-session view so a reviewer can download a CSV or JSON file in one click. It closes the frontend half of the epic #13 export gap.
+
+*   **[QA-SEC-01 (RBAC)](https://virtual-ai-patient.github.io/platform/qa/qa-rev3#4-security--privacy-qa-sec):** The Export button is shown only for scopes the current role can actually export — learners see it on their own session; educators/admins see it on cohort scope. No 403 dead-end from the UI.
+*   **[QA-REPRO-04 (Demo-sized datasets)](https://virtual-ai-patient.github.io/platform/qa/qa-rev3#6-reproducibility-qa-repro-new):** Downloads are triggered from the browser and streamed straight into a file — no intermediate in-memory buffer on the client, which keeps the demo build tolerant of small download sizes without extra tuning.
+*   **[QA-DOC-01 (Reviewer quickstart)](https://virtual-ai-patient.github.io/platform/qa/qa-rev3#7-documentation-handoff-qa-doc-new):** The UI element is discoverable within one click of the analytics page — a reviewer following the README quickstart can trigger an export without extra guidance.
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **OpenAPI client:** Regenerate via `frontend/openapi/openapi.bash` after task-01 lands so the export endpoints are typed.
+2.  **Repository:** `frontend/lib/domains/analytics/export_repository.dart` wraps the three export endpoints and returns a stream of bytes (not a fully-loaded body).
+3.  **UI surfaces:**
+    *   **Analytics screen (educator/admin):** An **Export** dropdown with entries: *Sessions (CSV)*, *Sessions (JSON)*, *Actions — this cohort (CSV)*, *Actions — this cohort (JSON)*. Cohort selection reuses the existing analytics filter state (`since`, `until`, `cohort_id`).
+    *   **Session debrief screen (learner + educator + admin):** An **Export actions** button next to the debrief header with CSV / JSON options for the current session only.
+4.  **Download trigger (Flutter web):** Use a Blob URL created from the streamed response body — the browser handles the actual file save. Show a loading spinner during the fetch and an explicit error surface if the response is 4xx/5xx.
+5.  **Role gating:** Hide the cohort exports for learners; show only the own-session export. Backend still enforces authorisation; the UI just avoids offering unreachable actions.
+6.  **Quality compliance:** **Flutter / Dart strong mode** with `flutter analyze` clean; explicit UI for loading / success / 403 / network-error states; widget tests in `frontend/test/features/analytics/` cover the button visibility per role and the trigger flow with a mocked repository.
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] Export dropdown is visible on the analytics screen for educator + admin, and hidden for learners.
+*   [ ] Export button is visible on the debrief screen for the session's owner, educator, and admin.
+*   [ ] Clicking any export entry triggers a browser download of a file with the correct extension (`.csv` or `.json`) and a filename that includes the scope and the time window.
+*   [ ] 403 responses render as an explicit error toast, not a silent failure.
+*   [ ] Widget tests cover role-based visibility (learner / educator / admin) and the download-trigger success + error flows.
+*   [ ] Epic #13's Definition-of-Done line **"Export feature working"** can be checked off once task-01 (backend) and this task both land.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/epic-rest-api/README.md
+++ b/docs/project management/epic-rest-api/README.md
@@ -1,0 +1,23 @@
+# Epic: REST API Backend — Evaluation & Analytics slice
+
+Tasks below cover the **Evaluation** and **Analytics** API categories of
+the REST API epic. Scope is intentionally trimmed for MVP: only Flutter
+client + FastAPI backend (no bot client), one backend task and one
+frontend task per API.
+
+Each file follows the `.github/ISSUE_TEMPLATE/task.yml` schema and can
+be pasted into a new GitHub Issue using the **Task** template.
+
+| # | Task | Side | API |
+|---|---|---|---|
+| 01 | Evaluation API: scoring engine + endpoints | Backend | Evaluation |
+| 02 | Evaluation UI: debrief & scores screen | Frontend | Evaluation |
+| 03 | Analytics API: aggregation + export endpoints | Backend | Analytics |
+| 04 | Analytics UI: dashboard + export trigger | Frontend | Analytics |
+
+Dependencies: 02 depends on 01; 04 depends on 03; 03 depends on 01
+(uses evaluation artifacts as input).
+
+All endpoints sit under `/v1` and follow the existing module pattern
+(`request.py` / `response.py` / `service.py` / `repository.py` /
+`router.py`) used by `backend/sessions/`.

--- a/docs/project management/epic-rest-api/task-01-backend-evaluation-api.md
+++ b/docs/project management/epic-rest-api/task-01-backend-evaluation-api.md
@@ -1,0 +1,32 @@
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+This enabler delivers the scoring backbone of the simulation: it converts the learner's diagnostic and treatment decisions into a structured, persisted evaluation that powers the debrief screen and any downstream analytics. Without this, `finish_session` ends a case with no measurable feedback to the learner.
+
+*   **[QA-PERF-03 (Debriefing Latency)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#2-performance--latency-qa-perf):** Automated evaluation and debriefing generation must complete in ≤ 5 seconds.
+*   **[QA-PERF-04 (API Latency)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#2-performance--latency-qa-perf):** Backend API p95 latency must be ≤ 500ms for the read endpoints.
+*   **[QA-REL-02 (Deterministic Evaluation)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#4-reliability--data-integrity-qa-rel):** Scoring must remain consistent regardless of LLM temperature or randomness — drives the rules-based scorer choice.
+*   **[QA-SEC-03 (RBAC)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#5-security--privacy-qa-sec):** Learners can only read their own evaluation; educators/admins can read any.
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **Endpoints:**
+    *   `GET /v1/sessions/{session_id}/scores`: Compact summary (total + four sub-scores) for list views and partner integrations.
+    *   `GET /v1/sessions/{session_id}/debrief`: Full debrief with structured findings and the reference (gold) solution.
+2.  **Data Schema (Evaluation Artifact):** Implement persisted models for:
+    *   **Evaluation:** `session_id` (unique), `case_version`, `total_score`, sub-scores for `diagnosis` / `diagnostics` / `treatment` / `safety`.
+    *   **EvaluationFinding:** `category`, `type`, `severity`, `expected`, `actual`, `why_matters`, `how_to_correct` — every deduction is explainable per §6.3 of the technical spec.
+    *   **Reference Solution:** Snapshot from the case used by the scorer at evaluation time.
+3.  **Scoring Engine:** New `backend/evaluation/` module (`repository.py`, `service.py`, `response.py`, `router.py`) following the existing `backend/sessions/` pattern. `service.score_session(session_id)` runs a rules-based scorer (diagnosis match, must-have/should-not-order tests, treatment coverage, hard safety violations), is idempotent on `session_id`, and is invoked from `finish_session` behind an `EVALUATION_AUTO_SCORE` flag.
+4.  **Quality Compliance:** Use **Python 3.14** with **MyPy --strict** for the new module; reject requests with 404 (missing session), 403 (non-owner), 409 (session not finished or not yet scored).
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] Alembic migration for `evaluations` and `evaluation_findings` applies cleanly and is reversible.
+*   [ ] `score_session` is idempotent per `session_id` and sub-scores sum to the total within rounding tolerance.
+*   [ ] `GET /v1/sessions/{id}/scores` and `GET /v1/sessions/{id}/debrief` are reachable and appear in Swagger UI with example responses.
+*   [ ] Authorization paths (owner 200, non-owner 403, admin 200, unfinished 409, missing 404) are covered by integration tests in `backend/tests/test_evaluation.py`.
+*   [ ] OpenAPI schema in `frontend/openapi/openapi.json` regenerates with no manual edits.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/epic-rest-api/task-02-frontend-evaluation-ui.md
+++ b/docs/project management/epic-rest-api/task-02-frontend-evaluation-ui.md
@@ -1,0 +1,30 @@
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+This enabler turns the evaluation artifact into the educational payoff of the simulation: a Flutter screen that shows the learner their score and, for every deduction, what was expected, what they did, and how to correct it. Without it, the backend scoring engine has no consumer.
+
+*   **[QA-PERF-03 (Debriefing Latency)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#2-performance--latency-qa-perf):** The debrief view must be perceived as instantaneous after `finish_session` returns — UI shows skeleton then content within the 5s envelope.
+*   **[QA-REL-01 (Data Integrity)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#4-reliability--data-integrity-qa-rel):** No learner submission or finding may be silently dropped by the client; every field returned by the backend is rendered.
+*   **[QA-SEC-03 (RBAC)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#5-security--privacy-qa-sec):** Client must surface 403 / 409 explicitly rather than fall back to "something went wrong".
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **OpenAPI client:** Regenerate via `frontend/openapi/openapi.bash` after the backend enabler lands so typed `ScoreSummary`, `Finding`, and `Debrief` models are available.
+2.  **Repository:** `frontend/lib/domains/evaluation/evaluation_repository.dart` wraps `GET /v1/sessions/{id}/scores` and `GET /v1/sessions/{id}/debrief`.
+3.  **Presentation:** `frontend/lib/features/evaluation/presentation/debrief_screen.dart` with three sections:
+    *   **Scores header** — total + four sub-scores.
+    *   **Findings list** — grouped by category, sorted high-severity first, each row showing `expected` / `actual` / `why_matters` / `how_to_correct`.
+    *   **Reference solution** — collapsible section.
+4.  **Navigation:** "Finish case" CTA and tapping a finished session in the cases list both open the debrief screen.
+5.  **Quality Compliance:** Use **Flutter / Dart strong mode** with `flutter analyze` clean; explicit UI for every state (loading, 200, 403, 404, 409 not-finished).
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] Debrief screen renders against a real backend in dev with no console errors on web and mobile targets.
+*   [ ] All four error states (loading, 403, 404, 409 not-finished) have explicit UI — no generic fallback.
+*   [ ] Findings are grouped by category and sorted with high-severity first.
+*   [ ] Widget tests in `frontend/test/features/evaluation/` cover loading, success, empty findings, 409, and 403 states and pass.
+*   [ ] Navigation from "Finish case" and from the cases list both reach the debrief screen.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/epic-rest-api/task-03-backend-analytics-api.md
+++ b/docs/project management/epic-rest-api/task-03-backend-analytics-api.md
@@ -1,0 +1,34 @@
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+This enabler exposes aggregate progress and a row-per-session export feed over sessions and evaluations. It powers the educator dashboard and is the primary surface a future partner platform will integrate against to pull learner progress into their LMS.
+
+*   **[QA-PERF-04 (API Latency)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#2-performance--latency-qa-perf):** Aggregation endpoints must hold p95 ≤ 500ms on a fixture dataset.
+*   **[QA-ARCH-02 (Action Trace)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#7-architecture--observability-qa-arch):** Structured logging of learner actions is the source of truth for analytics — this enabler reads it back out.
+*   **[QA-SEC-02 (Conversation Privacy)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#5-security--privacy-qa-sec):** Export must not include raw chat content; only structured submission + scoring fields.
+*   **[QA-SEC-03 (RBAC)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#5-security--privacy-qa-sec):** Cohort and export endpoints enforce educator/admin scopes.
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **Endpoints:**
+    *   `GET /v1/analytics/me?since=&until=`: Authenticated learner's own progress (score trend, case count, weakest sub-score).
+    *   `GET /v1/analytics/cohorts/{cohort_id}?since=&until=`: Cohort aggregates — educator/admin only.
+    *   `GET /v1/analytics/export?scope=&since=&until=&format=csv|json`: Streamed row-per-session feed.
+2.  **Data Schema (Aggregate Types):** Implement typed dataclasses for:
+    *   **LearnerProgress:** counts, average total + sub-scores, time-bucketed score trend.
+    *   **CohortSummary:** per-learner roll-up + cohort distribution histograms.
+    *   **ExportRow:** flat row with `session_id`, `case_id`, `case_version`, `learner_id`, `finished_at`, scores, finding counts per severity.
+3.  **Streaming + Safety:** Export uses FastAPI `StreamingResponse` driven by an async generator — no full materialization. CSV writer escapes RFC-4180 and rejects cells beginning with `=`, `+`, `-`, `@` to prevent spreadsheet injection.
+4.  **Quality Compliance:** Use **Python 3.14** with **MyPy --strict**; analytics queries are indexed and bounded by `since`/`until`; aggregations are deterministic against a fixture set.
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] Three endpoints reachable under `/v1/analytics/...` and visible in Swagger UI with example responses.
+*   [ ] Authorization enforced: learner reading another learner's cohort gets 403; admin can read any.
+*   [ ] Aggregations produce identical results across two runs on the same fixture set.
+*   [ ] Export streams a 5 000-row fixture without memory growing linearly in row count (verified by a benchmark test).
+*   [ ] CSV round-trips through Python's `csv` reader and rejects spreadsheet-injection-prone leading characters.
+*   [ ] Integration tests in `backend/tests/test_analytics.py` cover learner / cohort / export paths and all auth outcomes.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/epic-rest-api/task-04-frontend-analytics-ui.md
+++ b/docs/project management/epic-rest-api/task-04-frontend-analytics-ui.md
@@ -1,0 +1,30 @@
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+This enabler turns the analytics endpoints into a usable view: a role-aware Flutter dashboard that lets a learner see their own progress and an educator/admin inspect a cohort and trigger an export. Without it, the analytics backend has no consumer in the platform itself.
+
+*   **[QA-PERF-04 (API Latency)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#2-performance--latency-qa-perf):** Dashboard must feel responsive — loading skeletons appear immediately while the p95 ≤ 500ms backend call resolves.
+*   **[QA-SEC-03 (RBAC)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#5-security--privacy-qa-sec):** Layout is chosen from the user role returned by `/me`; client never assumes elevated scope.
+*   **[QA-ARCH-02 (Action Trace)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#7-architecture--observability-qa-arch):** Export trigger surfaces the structured action-trace data to educators in a portable format.
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **OpenAPI client:** Regenerate via `frontend/openapi/openapi.bash` after the backend analytics enabler lands.
+2.  **Repository:** `frontend/lib/domains/analytics/analytics_repository.dart` wraps `/v1/analytics/me`, `/v1/analytics/cohorts/{id}`, and the export endpoint.
+3.  **Presentation:**
+    *   `frontend/lib/features/analytics/presentation/dashboard_screen.dart` — role-aware layout (learner vs educator/admin), driven by the role from `/me`.
+    *   Widgets: `ScoreTrendChart`, `SubScoreBreakdown` reused across both modes.
+    *   `ExportButton` opens a dialog (scope, date range, format) and triggers download — web: blob download; mobile: share sheet.
+4.  **State handling:** Explicit UI for loading / empty / 403 / error states; the export button is disabled while a previous export is in flight.
+5.  **Quality Compliance:** **Flutter / Dart strong mode** with `flutter analyze` clean; widget tests cover the two chart widgets and a flow test exercises the export dialog with a mocked repository.
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] Dashboard renders against a real backend in dev for learner and educator/admin roles with no console errors.
+*   [ ] Empty date ranges render explicit placeholder states for every widget.
+*   [ ] Export produces a valid CSV file on web and mobile (verified manually + flow test).
+*   [ ] Widget tests cover `ScoreTrendChart`, `SubScoreBreakdown`, and the export dialog flow and pass.
+*   [ ] 403 from a cohort endpoint surfaces an explicit "You don't have access to this cohort" message rather than a generic fallback.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/epic-safety/README.md
+++ b/docs/project management/epic-safety/README.md
@@ -1,0 +1,24 @@
+# Epic: AI Safety & Guardrails — Minimum viable breakdown
+
+No external customer yet, so this slice covers only what's needed to keep
+the AI patient in-character and prevent obvious unsafe output. Heavy
+machinery (dedicated monitoring service, dashboards, audit DB tables,
+compliance review process) is intentionally out of scope until a partner
+or pilot demands it.
+
+Each task file follows the `.github/ISSUE_TEMPLATE/task.yml` schema and
+can be pasted into a new GitHub Issue using the **Task** template.
+
+| # | Task | What it covers from the epic |
+|---|---|---|
+| 01 | Prompt guardrails + refusal template | Prompt-level constraints, role-lock, no-real-advice rule |
+| 02 | Bot-side safety filter + disclaimers | Policy/output filtering, training-only disclaimers, simple stdout logging of violations |
+| 03 | Red-team tests + short safety doc | Test suite for common violations, brief compliance section in existing docs |
+
+Explicitly deferred until there's a pilot/customer ask:
+- dedicated `safety_events` DB table and admin API,
+- monitoring service, dashboards, paging alerts,
+- versioned disclaimer registry and per-session acknowledgement records,
+- separate compliance document with sign-off workflow.
+
+Depends on EPIC-03 (Conversational Virtual Patient Engine).

--- a/docs/project management/epic-safety/task-01-prompt-guardrails.md
+++ b/docs/project management/epic-safety/task-01-prompt-guardrails.md
@@ -1,0 +1,38 @@
+# [Task]: Prompt-level guardrails + canonical refusal template
+
+## Task Description & Context
+
+The `BЕЗОПАСНОСТЬ` block in
+`backend/core/ai_orchestrator.build_system_prompt` already covers
+role-stay and basic jailbreak resistance. For MVP we want to harden it
+slightly so the patient persona explicitly refuses real-world medical
+advice and out-of-scenario questions with a consistent phrase the bot
+filter (task 02) and tests (task 03) can recognize.
+
+No new modules, no per-section structure — just a tighter safety block
+and a shared constant for the refusal phrase.
+
+## Subtasks
+
+- [ ] Add a `SAFETY_REFUSAL` constant in `backend/core/ai_orchestrator.py`
+      (or a tiny `safety.py` next to it) with the canonical refusal
+      text: "Я только пациент в учебном сценарии…".
+- [ ] Extend the existing `BЕЗОПАСНОСТЬ` block in `build_system_prompt`
+      to:
+      - forbid giving real-world dosing or treatment recommendations,
+      - forbid disclosing the hidden gold-standard answer,
+      - require the canonical refusal phrase when asked anything
+        outside the simulation.
+- [ ] Add 2–3 unit tests in `backend/tests/test_llm_orchestrator.py`
+      asserting the new rules appear in every built prompt.
+
+## Task Acceptance Criteria
+
+- [ ] `SAFETY_REFUSAL` constant exists and is importable.
+- [ ] Built system prompt always contains the three new rules and the
+      refusal phrase.
+- [ ] New tests pass.
+
+## Sub-issues
+
+Sub-issues are blockers for this task.

--- a/docs/project management/epic-safety/task-02-bot-safety-filter-and-disclaimer.md
+++ b/docs/project management/epic-safety/task-02-bot-safety-filter-and-disclaimer.md
@@ -1,0 +1,54 @@
+# [Task]: Bot-side safety filter + training-only disclaimer
+
+## Task Description & Context
+
+Single lightweight layer in the Telegram bot that does three things:
+
+1. Shows a "training only, not real medical advice" disclaimer on
+   `/start` and at case launch.
+2. Inspects inbound user messages and outbound AI replies against a
+   small keyword/regex list; on a hit either rewrites the reply with
+   the refusal phrase from task 01 or logs and lets it through.
+3. Logs every non-pass decision via the existing Python logger (no DB
+   table, no admin API) so we can grep the bot logs during pilot.
+
+This collapses the original "policy layer", "output content filter",
+"disclaimers", "safety event storage", and "monitoring" tasks into one
+file that's actually shippable for MVP.
+
+## Subtasks
+
+- [ ] Add `bot/safety.py` with:
+      - `DISCLAIMER` constant (one short paragraph),
+      - `check(text, direction) -> (action, category)` where
+        `action ∈ {"pass", "rewrite"}`,
+      - small keyword/regex lists for: real-medical-advice request,
+        break-character/jailbreak attempt, harmful instructions
+        (self-harm / illegal drugs).
+- [ ] In `bot/bot.py`:
+      - send `DISCLAIMER` on `/start` and as the first message of any
+        new case session,
+      - run `check(..., "inbound")` before calling the backend; on
+        `rewrite`, reply with the refusal phrase and skip the backend
+        call,
+      - run `check(..., "outbound")` on the backend reply; on
+        `rewrite`, substitute the refusal phrase,
+      - on any non-pass decision, `logger.warning("safety", extra={...})`
+        with `category`, `direction`, `excerpt`.
+- [ ] Smoke test in `backend/tests/` or `bot/tests/` (pick whichever
+      exists) covering: clean message passes, "give me a real
+      prescription" rewrites, "ignore previous instructions" rewrites.
+
+## Task Acceptance Criteria
+
+- [ ] `/start` and case launch both post the disclaimer.
+- [ ] At least one positive and one negative case per category passes
+      in the smoke test.
+- [ ] Every rewrite emits a `logger.warning` line with
+      `category`, `direction`, and a short `excerpt`.
+- [ ] No new DB tables, no new HTTP endpoints (kept minimal on
+      purpose).
+
+## Sub-issues
+
+Sub-issues are blockers for this task.

--- a/docs/project management/epic-safety/task-03-safety-tests-and-doc.md
+++ b/docs/project management/epic-safety/task-03-safety-tests-and-doc.md
@@ -1,0 +1,37 @@
+# [Task]: Red-team tests + short safety doc section
+
+## Task Description & Context
+
+Closes the epic's "test suite for common safety violation attempts" and
+"documentation of safety mechanisms" bullets at a level appropriate for
+pre-pilot scope — a small pytest module and a short section appended
+to an existing QA doc, not a separate compliance deliverable.
+
+## Subtasks
+
+- [ ] Add `backend/tests/test_safety.py` with ~12 prompts across four
+      scenarios from the epic:
+      - asking for real medical advice,
+      - break-character / "ignore previous instructions",
+      - harmful instructions (self-harm / illegal drug),
+      - context-boundary probing (asking for the gold standard).
+- [ ] For each prompt, assert `bot.safety.check` returns `rewrite` with
+      the expected category. (No LLM call needed — we test the filter,
+      not the model.)
+- [ ] Add a "Safety mechanisms" subsection to `docs/qa/index.md` (or
+      the latest `qa-rev*.md`) listing:
+      - the prompt-level rules from task 01,
+      - the bot filter and disclaimer from task 02,
+      - the test module from this task,
+      - what's intentionally out of scope until pilot.
+
+## Task Acceptance Criteria
+
+- [ ] `pytest backend/tests/test_safety.py` passes locally and in CI.
+- [ ] Each of the four scenarios has at least 3 prompts.
+- [ ] The QA doc subsection links to the three code paths
+      (`build_system_prompt`, `bot/safety.py`, `test_safety.py`).
+
+## Sub-issues
+
+Sub-issues are blockers for this task.

--- a/docs/project management/feature-communication-evaluation/README.md
+++ b/docs/project management/feature-communication-evaluation/README.md
@@ -1,0 +1,14 @@
+# Feature: LLM-based communication evaluation
+
+Evaluate how well the learner's conversation with the virtual patient
+matches medical communication norms (open-ended questions, empathy,
+structured history-taking, closing the loop, avoidance of leading
+questions). Runs as an LLM-as-judge over the persisted chat log of a
+session and surfaces a per-criterion breakdown in the debrief.
+
+| # | Task | Side |
+|---|---|---|
+| 01 | LLM-based communication evaluation API | Backend |
+| 02 | Communication evaluation panel in debrief | Frontend |
+
+Dependency: 02 depends on 01.

--- a/docs/project management/feature-communication-evaluation/task-01-backend-communication-evaluation-api.md
+++ b/docs/project management/feature-communication-evaluation/task-01-backend-communication-evaluation-api.md
@@ -1,0 +1,36 @@
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+The current rules-based evaluator scores diagnosis, diagnostics, treatment, and safety, but the doctor–patient conversation itself is unscored. Communication quality (open-ended questions, empathy, structured history-taking, closing the loop, avoidance of leading questions) is a primary educational target of the simulation. This enabler runs an LLM-as-judge over the persisted chat log and emits a per-criterion communication score that the debrief screen can display.
+
+*   **[QA-PERF-03 (Debriefing Latency)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#2-performance--latency-qa-perf):** Automated evaluation must complete in ≤ 5 seconds — the judge runs once per finished session, not on every chat turn.
+*   **[QA-REL-02 (Deterministic Evaluation)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#4-reliability--data-integrity-qa-rel):** Judge calls use `temperature=0` and a fixed rubric prompt so re-runs over the same chat yield the same score.
+*   **[QA-ARCH-01 (Pluggable AI Adapters)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#7-architecture--observability-qa-arch):** Judge calls go through the existing `AIProvider` interface so the model can be swapped without touching scoring logic.
+*   **[QA-SAFE-02 (No Real Medical Advice)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#6-ai-safety--guardrails-qa-safe):** Judge prompt is constrained to communication style only — it must not emit any clinical recommendation back to the learner.
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **Endpoints:**
+    *   `POST /v1/sessions/{session_id}/communication-evaluation`: Triggers (or re-runs) the LLM judge over the session's chat log. Idempotent: returns the existing record if already scored.
+    *   `GET /v1/sessions/{session_id}/communication-evaluation`: Returns the persisted per-criterion result.
+2.  **Data Schema (Communication Evaluation):**
+    *   **CommunicationEvaluation:** `session_id` (unique), `model`, `prompt_version`, `total_score` (0–100), `created_at`.
+    *   **CommunicationCriterion:** `evaluation_id`, `criterion` (e.g. `open_ended_questions`, `empathy`, `structured_history`, `closing_the_loop`, `no_leading_questions`), `score` (0–5), `rationale`, `quote` (short excerpt from the chat).
+3.  **Judge pipeline (`backend/communication_eval/service.py`):**
+    *   Loads the full `ActionLog` for the session, filters to user/assistant turns, and renders them as a numbered transcript.
+    *   Sends a single LLM call via `AIProvider.complete` with `temperature=0` and a versioned rubric prompt that requires JSON output (score per criterion + short rationale + a verbatim quote from the transcript).
+    *   Validates the JSON against a Pydantic schema; rejects with a 502 and an error event if it doesn't parse.
+    *   Persists the result through `backend/communication_eval/repository.py`.
+4.  **Quality Compliance:** **Python 3.14** with **MyPy --strict**; finished session required (409 if not); ownership/admin auth identical to `/scores` and `/debrief`.
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] Alembic migration for `communication_evaluations` and `communication_criteria` applies cleanly and is reversible.
+*   [ ] `POST .../communication-evaluation` is idempotent per `session_id` (second call returns the existing record).
+*   [ ] Both endpoints reachable under `/v1/sessions/{id}/communication-evaluation` and visible in Swagger UI.
+*   [ ] Re-running the judge on the same transcript with the same `prompt_version` yields identical scores (verified by a test using the mock provider).
+*   [ ] Judge rejects malformed JSON output with a clear 502 instead of corrupting the DB.
+*   [ ] Auth paths covered by tests: owner 200, non-owner 403, admin 200, unfinished session 409, missing session 404.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/feature-communication-evaluation/task-02-frontend-communication-evaluation-ui.md
+++ b/docs/project management/feature-communication-evaluation/task-02-frontend-communication-evaluation-ui.md
@@ -1,0 +1,30 @@
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+Without a frontend surface, the communication evaluation never reaches the learner. This enabler adds a dedicated panel to the existing debrief screen that shows the total communication score, a per-criterion breakdown (open-ended questions, empathy, structured history, closing the loop, no leading questions), and the quoted excerpt the judge used for each rationale — so the learner can see exactly what they said.
+
+*   **[QA-PERF-03 (Debriefing Latency)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#2-performance--latency-qa-perf):** Panel must render skeletons immediately and replace them with real content once the 5s judge envelope resolves.
+*   **[QA-REL-01 (Data Integrity)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#4-reliability--data-integrity-qa-rel):** Every criterion + rationale + quote returned by the backend is displayed; nothing silently dropped by the client.
+*   **[QA-SAFE-02 (No Real Medical Advice)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#6-ai-safety--guardrails-qa-safe):** Panel renders the judge output as feedback on the learner's style, never as actionable clinical advice — surface as "communication coaching".
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **OpenAPI client:** Regenerate via `frontend/openapi/openapi.bash` after the backend enabler lands so `CommunicationEvaluation` and `CommunicationCriterion` models are available.
+2.  **Repository:** `frontend/lib/domains/evaluation/communication_repository.dart` wraps `POST` (trigger) and `GET` (fetch) endpoints.
+3.  **Presentation:** Add a `CommunicationPanel` widget to `frontend/lib/features/evaluation/presentation/debrief_screen.dart`:
+    *   Header: total communication score with a coloured pill.
+    *   Body: a list of criterion rows, each with score (0–5), rationale, and the verbatim quote in a quote block.
+    *   Empty state: "Communication scoring not available for this session" if the `GET` returns 404.
+4.  **Trigger logic:** On entering the debrief screen, the client `GET`s the evaluation. If it returns 404, the client `POST`s once to trigger and re-fetches. Subsequent visits skip the `POST`.
+5.  **Quality Compliance:** **Flutter / Dart strong mode** with `flutter analyze` clean; explicit UI for loading / 200 / 404-not-yet-scored / 403 / 502-bad-judge-output states.
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] `CommunicationPanel` renders inside the debrief screen against a real backend in dev with no console errors on web and mobile.
+*   [ ] Trigger-on-404 flow runs exactly once per session per app launch (verified by a flow test).
+*   [ ] Each criterion row shows score, rationale, and the verbatim quote.
+*   [ ] All five error/empty states (loading, 200, 404, 403, 502) have explicit UI — no generic fallback.
+*   [ ] Widget tests in `frontend/test/features/evaluation/` cover loading, success, 404 (with trigger), and 403 states and pass.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/feature-persistent-sessions/README.md
+++ b/docs/project management/feature-persistent-sessions/README.md
@@ -1,0 +1,17 @@
+# Feature: Persistent sessions (resume after disconnect)
+
+Sessions are already persisted server-side (`case_sessions` + `action_logs`)
+and have an `active|completed|abandoned` lifecycle, but the resume path
+is not exposed: `POST /sessions/start` always creates a fresh session,
+no endpoint lists the user's active sessions, and the Flutter client
+loses chat state on logout, app kill, or network drop.
+
+This feature closes the gap so a learner can sign back in (or reopen the
+app after a power cut) and pick up exactly where they left off.
+
+| # | Task | Side |
+|---|---|---|
+| 01 | Active-sessions list + session-state rehydration API | Backend |
+| 02 | "You have unfinished sessions" UI + resume flow | Frontend |
+
+Dependency: 02 depends on 01.

--- a/docs/project management/feature-persistent-sessions/task-01-backend-persistent-sessions-api.md
+++ b/docs/project management/feature-persistent-sessions/task-01-backend-persistent-sessions-api.md
@@ -1,0 +1,35 @@
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+Today `case_sessions` already persists every learner action server-side, but the resume path is not exposed: there is no endpoint to list a user's active sessions, no endpoint to return the full state needed to rehydrate a client (frozen case snapshot, chat history, ordered tests, current conclusions), and `POST /sessions/start` will happily create a parallel duplicate session for the same case. This enabler closes those gaps so a logout, app kill, or power cut never costs the learner their work.
+
+*   **[QA-REL-01 (Data Integrity)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#4-reliability--data-integrity-qa-rel):** Zero loss of session state — this is the headline driver.
+*   **[QA-PERF-04 (API Latency)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#2-performance--latency-qa-perf):** State rehydration endpoint must hold p95 ≤ 500 ms even on a long chat log.
+*   **[QA-SEC-03 (RBAC)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#5-security--privacy-qa-sec):** Learners only see their own active sessions; admins can see any.
+*   **[QA-ARCH-02 (Action Trace)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#7-architecture--observability-qa-arch):** Resume is rebuilt from `action_logs` so the action trace remains the single source of truth.
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **Endpoints:**
+    *   `GET /v1/sessions/active`: Returns the caller's `active` sessions with `session_id`, `case_id`, `case_title`, `created_at`, `last_activity_at`, and `progress_summary` (turn count, has-conclusions flag).
+    *   `GET /v1/sessions/{session_id}/state`: Full rehydration payload — `session` metadata, `case_snapshot`, chat history (windowed but with `next_cursor` for pagination), `ordered_tests`, and current `conclusions`.
+    *   `POST /v1/sessions/{session_id}/abandon`: Explicitly mark a session abandoned (used when the learner chooses "start fresh" on the unfinished-sessions prompt).
+2.  **Behaviour changes to existing endpoints:**
+    *   `POST /sessions/start` now returns `409 Conflict` with the existing `session_id` if the caller already has an `active` session for the same `case_id`. A new `force=true` query flag abandons the old one and starts fresh.
+    *   Every successful chat turn / order-test / save-conclusions call updates a new `last_activity_at` column on `case_sessions`.
+3.  **Data schema additions:**
+    *   `case_sessions.last_activity_at` (timestamptz, indexed) maintained by the existing service-layer write paths.
+    *   `SessionRepository.list_active_by_user(user_id)` and `SessionRepository.touch(session_id)` helpers.
+4.  **Quality Compliance:** **Python 3.14** with **MyPy --strict**; ownership/admin auth on all three new endpoints; integration tests in `backend/tests/test_persistent_sessions.py` covering list, rehydrate, conflict on duplicate start, force-start, abandon.
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] Alembic migration adds `case_sessions.last_activity_at` (indexed) and is reversible.
+*   [ ] `GET /v1/sessions/active` returns only the caller's active sessions, sorted by `last_activity_at desc`.
+*   [ ] `GET /v1/sessions/{id}/state` rehydrates a finished test session into an equivalent client state on the next login (verified by an end-to-end test).
+*   [ ] `POST /sessions/start` returns 409 with the existing `session_id` when an active session already exists for the same case; `force=true` abandons it and starts fresh.
+*   [ ] `last_activity_at` is updated by chat, order-test, and save-conclusions writes (covered by tests).
+*   [ ] All three new endpoints appear in Swagger UI with example responses.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/feature-persistent-sessions/task-02-frontend-persistent-sessions-ui.md
+++ b/docs/project management/feature-persistent-sessions/task-02-frontend-persistent-sessions-ui.md
@@ -1,0 +1,29 @@
+### <h2> Justification / Business Value <a id="justification-business-value" href="#justification-business-value">🔗</a> </h2>
+
+Even with the backend persistence in place, the Flutter client today drops chat state on logout, app kill, or network drop and silently lets the learner start a duplicate session on the same case. This enabler adds a "You have unfinished sessions" surface on app launch and a resume flow that calls the new rehydration endpoint so the learner picks up exactly where they left off.
+
+*   **[QA-REL-01 (Data Integrity)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#4-reliability--data-integrity-qa-rel):** Client must never silently overwrite or lose persisted session state — every interruption recovers cleanly on next launch.
+*   **[QA-PERF-04 (API Latency)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#2-performance--latency-qa-perf):** Unfinished-sessions check happens once on launch behind a loading skeleton; resume payload is hydrated before navigation completes.
+*   **[QA-SEC-03 (RBAC)](https://virtual-ai-patient.github.io/platform/qa/qa-rev2.html#5-security--privacy-qa-sec):** Resume relies on the authenticated `/me` token; sessions belonging to other users are never reachable from the resume UI.
+
+### <h2> Proposed Technical Implementation <a id="proposed-technical-implementation" href="#proposed-technical-implementation">🔗</a> </h2>
+
+1.  **OpenAPI client:** Regenerate via `frontend/openapi/openapi.bash` after the backend enabler lands.
+2.  **Repository:** Extend `frontend/lib/domains/sessions/session_repository.dart` with `listActive()`, `getState(sessionId)`, `abandon(sessionId)`, and a `start(caseId, {force})` that handles the 409-with-existing-session response.
+3.  **Launch hook:** On successful auth, the app shell calls `listActive()`. If the result is non-empty, present an `UnfinishedSessionsSheet` modal with one row per active session: case title, last activity, progress summary, and two actions — **Resume** and **Abandon**.
+4.  **Resume flow:** "Resume" fetches `/state`, hydrates the chat, ordered tests, and conclusions stores, then navigates to the case session screen at the last turn. "Abandon" calls `POST .../abandon` and removes the row from the sheet.
+5.  **Duplicate-start handling:** When the learner taps "Start case" on a case they already have active, the existing 409 response opens a dialog: "You already have an unfinished session for this case" → **Resume existing** | **Start fresh** (calls `start(force: true)`).
+6.  **Quality Compliance:** **Flutter / Dart strong mode** with `flutter analyze` clean; explicit UI for loading, empty, 200, 403, and network-error states.
+
+### <h2> Acceptance Criteria (AC) <a id="acceptance-criteria-ac" href="#acceptance-criteria-ac">🔗</a> </h2>
+
+*   [ ] `UnfinishedSessionsSheet` opens automatically after login when the user has at least one active session.
+*   [ ] "Resume" rehydrates chat history, ordered tests, and current conclusions identically to the state before disconnect (verified by an end-to-end test using a recorded session fixture).
+*   [ ] "Abandon" removes the session from the sheet and is reflected by a `409 → no longer active` on any subsequent action.
+*   [ ] Tapping "Start case" on a case with an active session opens the duplicate-start dialog instead of creating a parallel session.
+*   [ ] Sheet, dialog, and resume flow each have explicit loading / empty / error UI — no generic fallback.
+*   [ ] Widget tests cover the sheet (empty + populated), the duplicate-start dialog, and the resume hydration flow with a mocked repository.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are type `Task` issues that must be resolved to resolve this issue.

--- a/docs/project management/pivot-startup-proposal/README.md
+++ b/docs/project management/pivot-startup-proposal/README.md
@@ -1,0 +1,51 @@
+# Pivot to startup proposal — documentation update issues
+
+The customer engagement (Third Opinion) ended because of an NDA
+blocker with Innopolis University. With two weeks left in the course,
+the coordinator approved a pivot: instead of shipping a product to a
+customer, the team delivers a **startup proposal backed by a validated
+prototype**.
+
+This folder contains the GitHub-style issues (task-template format)
+for realigning every practice-area document to that new goal. Each
+issue is scoped to one document and one owner; together they cover
+the full documentation set required for the final presentation.
+
+## Summary table
+
+| # | Title | Owner (GitHub) | Labels |
+|---|---|---|---|
+| 01 | Reframe `technical-product-description.md` as startup-proposal context | Alina (`rayderdo`) + Timur (`timur-harin`) | `documentation` |
+| 02 | Rewrite Strategic Planning as Discovery → P1/P2/P3 → Proposal Finalisation | Karim (`GrandAdmiralBee`) | `documentation` |
+| 03 | Rewrite Tactical Planning around hypothesis-closure ritual and new DoD | Karim (`GrandAdmiralBee`) | `documentation` |
+| 04 | Replace QA thresholds with proposal-validation criteria | Karim (`GrandAdmiralBee`) | `documentation` |
+| 05 | Add LLM Patient Role Design section to `system-architecture.md` | Aizat (`muitiiifruckt`) | `documentation`, `component: ai` |
+| 06 | Update Configuration Management to the new Level 1–5 hierarchy + User Insight artifact | Karim (`GrandAdmiralBee`) | `documentation` |
+| 07 | Reframe CI/CD doc from production-readiness to demo-stability; add prototype tagging | Ilnar (`ilnarkhasanov`) | `documentation`, `component: backend` |
+| 08 | Create `docs/proposal/hypotheses.md` (living hypothesis tracker for P1/P2/P3) | Karim (`GrandAdmiralBee`) | `documentation` |
+| 09 | Create `docs/proposal/patient-role-research.md` (Aizat's LLM findings) | Aizat (`muitiiifruckt`) | `documentation`, `component: ai` |
+| 10 | Create `docs/proposal/user-insights.md` (running log of interviews + corridor tests) | Alina (`rayderdo`) | `documentation` |
+| 11 | Architecture doc cleanup — final nginx sweep, qa-rev3 cross-refs, formal diagram-notation labels | Ilnar (`ilnarkhasanov`) | `documentation`, `component: backend` |
+| 12 | Online docs cleanup — split site nav into "Current — Startup Proposal" and "Historical — Product for Customer" | Karim (`GrandAdmiralBee`) | `documentation` |
+
+## Iteration → owner map
+
+| Iteration | Hypothesis | Owner |
+|---|---|---|
+| P1 — Patient Role | LLM can convincingly simulate lying, forgetting, and emotional states | Aizat |
+| P2 — Case System | Constrained test budget changes how learners reason | Ilnar + Timur |
+| P3 — Full Loop | Complete flow feels like a game, not a form | All |
+
+## New artifact hierarchy (Level 1–5)
+
+```
+L1  Goal statement (this pivot document)
+L2  Expert meeting notes + user interview summaries
+L3  Hypothesis per prototype iteration + Value Proposition Canvas
+L4  GitHub Issues (research + prototype tasks)
+L5  Prototype version + validation results
+```
+
+Change trigger: new insight from user interview or expert session
+→ Alina writes insight summary → Karim creates/updates issues
+→ team updates prototype → Karim validates against hypothesis DoD.

--- a/docs/project management/pivot-startup-proposal/issue-01-update-technical-product-description.md
+++ b/docs/project management/pivot-startup-proposal/issue-01-update-technical-product-description.md
@@ -1,0 +1,28 @@
+**Owners:** Alina (`rayderdo`) &nbsp;·&nbsp; Timur (`timur-harin`) &nbsp;·&nbsp; **Labels:** `documentation`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+The customer engagement (Third Opinion) ended over an NDA blocker with Innopolis University. The course coordinator approved a pivot: instead of delivering a product to a real customer, the team delivers a **startup proposal backed by a validated prototype**. `docs/product/technical-product-description.md` currently reads as a product spec addressed to a customer — it needs to be reframed as the product-context section of that proposal.
+
+The reframed document should explain: what problem we address, why the market is validated (similar platforms exist), and why we can compete despite that (quality of execution — patient-role realism, structured case system, game mechanics). It should also state explicitly that business modelling and financial projections are out of scope, so a reviewer understands the SE-course boundary rather than reading it as a gap.
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Replace section 1 ("Product summary") with a **Problem statement** and a **Market context** paragraph (similar platforms exist; differentiation is quality of execution — per the domain-expert meeting).
+- [ ] Rewrite the users section to keep the same three roles (learner / educator / admin) but frame each around what the *prototype* demonstrates, not what a shipped product would do.
+- [ ] Add a **Differentiators** section: LLM patient role quality (lying / forgetting / emotions / hesitation), constrained-resource case system (test budget + test–case compatibility), game mechanics (Doctor House reference).
+- [ ] Add an explicit **Scope boundaries** section: no business model, no financial projections, no go-to-market — with a one-line rationale ("SE-course scope; business analysis would be speculation without real market data").
+- [ ] Remove or trim any requirement worded as a customer commitment (SLAs, integration guarantees, milestone dates tied to Third Opinion).
+- [ ] Cross-link the doc from `docs/README.md` and from `docs/proposal/hypotheses.md` once that file exists.
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] The document opens with a problem statement + market-context paragraph, not with a product summary.
+- [ ] "Differentiators" section names all three: patient role quality, constrained case system, game mechanics.
+- [ ] "Scope boundaries" section explicitly lists what is out of scope (business model, financials, GTM) and why.
+- [ ] No requirement in the document reads as a commitment to a specific customer or a specific pilot deployment.
+- [ ] `docs/README.md` link to `technical-product-description.md` still resolves; the doc renders cleanly with the site's Jekyll build (no broken links, no leftover TODOs).
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-02-update-strategic-planning.md
+++ b/docs/project management/pivot-startup-proposal/issue-02-update-strategic-planning.md
@@ -1,0 +1,28 @@
+**Owner:** Karim (`GrandAdmiralBee`) &nbsp;·&nbsp; **Labels:** `documentation`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+`docs/project management/strategic-planning.md` currently lays out a 5-month, epic-driven product roadmap (Foundation → Core MVP → Medical Workflow → MVP Complete → Final Polish). With the pivot to a startup proposal, that structure no longer matches what we deliver: there is no product to ship, only a proposal to defend, and the remaining time is measured in weeks, not months.
+
+Replace the roadmap with a three-phase plan matched to the pivot: **Discovery → Prototype Iterations (P1/P2/P3) → Proposal Finalisation**. Each phase is tied to hypotheses (from `docs/proposal/hypotheses.md`) and to the artifacts that close them, so a reviewer can trace every phase to evidence rather than to a delivered feature.
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Replace section 2 ("Strategic Overview") timeline with the three-phase plan; keep an ASCII timeline block, but with Discovery / P1 / P2 / P3 / Proposal Finalisation instead of monthly product phases.
+- [ ] For each phase, list: entry criteria, exit criteria (a hypothesis is confirmed or refuted), owner, and the artifact that records the outcome.
+- [ ] Replace the "Key Milestones" table: milestones are now Discovery-complete, P1-validated, P2-validated, P3-validated, Proposal-ready.
+- [ ] Remove all references to `EPIC-00 … EPIC-14` — these belonged to the old feature-delivery roadmap.
+- [ ] Add a short **Risks & mitigations** subsection focused on proposal risk (e.g. "hypothesis refuted" → what happens next, not on delivery slip).
+- [ ] Cross-link to the tactical plan (issue #3) and to `docs/proposal/hypotheses.md` (issue #8).
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] Roadmap consists of exactly three phases: Discovery, Prototype Iterations (P1/P2/P3), Proposal Finalisation.
+- [ ] Each phase has explicit exit criteria worded as "hypothesis H_x confirmed / refuted by evidence".
+- [ ] Milestones table lists no product feature — only hypothesis-validation and proposal-readiness milestones.
+- [ ] No dangling references to `EPIC-*` remain in the document.
+- [ ] Risks section addresses proposal-level risk (hypothesis refutation, insufficient user contacts) rather than delivery-schedule risk.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-03-update-tactical-planning.md
+++ b/docs/project management/pivot-startup-proposal/issue-03-update-tactical-planning.md
@@ -1,0 +1,27 @@
+**Owner:** Karim (`GrandAdmiralBee`) &nbsp;·&nbsp; **Labels:** `documentation`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+`docs/project management/tactical-planning.md` describes a weekly rhythm oriented around delivering features to Denis on Thursday. The weekly rhythm itself stays (Monday planning, Wednesday sync, Thursday mentor demo, Friday retro), but the *content* of a sprint changes: tasks are no longer feature-delivery items but research and validation tasks that advance a hypothesis.
+
+The document needs a new **hypothesis-closure ritual** section — who decides that a hypothesis is validated / refuted, when that decision happens, and what artifact records it. It also needs an updated **Definition of Done**: a task is done only when both (a) the artifact is created and (b) the linked hypothesis has advanced (new evidence, refined claim, or closed). "Tests pass" is no longer sufficient by itself.
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Keep section 2 ("Weekly Tactical Rhythm") as-is except: rename "Denis Feedback Session" to "Mentor / Expert Feedback Session" and add a note that this is where hypothesis-closure decisions happen.
+- [ ] Add a new section **"Hypothesis closure ritual"**: trigger (evidence collected), decision-maker (Karim + owner of the hypothesis), artifact updated (`docs/proposal/hypotheses.md`), and how a refutation is handled (open a new issue, do not silently drop).
+- [ ] Update the **Definition of Done** section (or add it if not present) with two parts: DoD-task (artifact created **and** hypothesis advanced) and DoD-iteration (hypothesis explicitly confirmed or refuted with linked evidence).
+- [ ] Add a **Traceability rule** line: every issue references at least one Level 2 or Level 3 artifact (per `docs/cm/configuration-management.md`).
+- [ ] Remove any wording that implies feature-count velocity as a success metric.
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] "Hypothesis closure ritual" section exists and names decision-maker, trigger, and updated artifact.
+- [ ] DoD is expressed in two parts (task-level and iteration-level), and both require hypothesis advancement — not only test/lint success.
+- [ ] Weekly rhythm still shows Monday planning + Thursday mentor session + Friday retro (nothing is lost).
+- [ ] Traceability rule appears in the doc and points to `docs/cm/configuration-management.md`.
+- [ ] No mention of "features shipped per sprint" as a success metric.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-04-update-qa-doc.md
+++ b/docs/project management/pivot-startup-proposal/issue-04-update-qa-doc.md
@@ -1,0 +1,34 @@
+**Owner:** Karim (`GrandAdmiralBee`) &nbsp;·&nbsp; **Labels:** `documentation`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+`docs/qa/qa-rev3.md` already trimmed production-grade NFRs down to prototype hygiene (repro + docs + basic safety). With the further pivot to a **startup proposal**, the QA doc needs one more pass: thresholds must now be **proposal-validation criteria**, and each threshold must be traceable to either a **domain-expert insight** or a **user interview finding** — not to a hypothetical customer requirement.
+
+The concrete new criteria (patient-role believability ≥ 4/5, case-system usability, 30-min demo stability, hypothesis coverage, proposal-claim traceability) come from the pivot planning document. Each of them must land in the QA doc with an explicit **rationale link** to the artifact that motivated it (expert meeting notes for role believability, user interviews for usability, and so on).
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Open a new revision `docs/qa/qa-rev4.md` (do not overwrite rev3 — the changelog rule requires a new file).
+- [ ] Add five validation criteria as first-class attributes:
+    - Patient role believability — expert rates ≥ 4/5.
+    - Case system usability — user completes P2 case unassisted.
+    - Prototype stability — no crash during a 30-minute demo.
+    - Hypothesis coverage — all three hypotheses tested before final presentation.
+    - Proposal claim traceability — every claim in the proposal links to a Level 2 artifact.
+- [ ] For each criterion, add a **Rationale** field with a link to the source artifact (`docs/proposal/user-insights.md`, expert-meeting notes, etc.).
+- [ ] Keep QA-REPRO and QA-DOC categories from rev3 — those still apply to the prototype-artifact side.
+- [ ] Drop QA-PERF-01/02/03 if they no longer serve the proposal (chat latency ≤ 2s is still nice, but only if the demo-stability criterion doesn't already cover it — decide and justify in the changelog).
+- [ ] Add a changelog entry pointing to this pivot document as the trigger.
+- [ ] Update `docs/qa/index.md` nav order so rev4 appears at the top of the QA history.
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] `docs/qa/qa-rev4.md` exists with the five new validation criteria.
+- [ ] Every criterion has a Rationale field pointing to either an expert-meeting artifact or a user-insight artifact.
+- [ ] Changelog entry names the pivot as the trigger and lists what was dropped from rev3 and why.
+- [ ] `docs/qa/qa-rev3.md` remains untouched (historical record).
+- [ ] Jekyll build renders rev4 in the QA nav without errors.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-05-update-architecture-doc.md
+++ b/docs/project management/pivot-startup-proposal/issue-05-update-architecture-doc.md
@@ -1,0 +1,29 @@
+**Owner:** Aizat (`muitiiifruckt`) &nbsp;·&nbsp; **Labels:** `documentation`, `component: ai`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+The pivot to a startup proposal moves the emphasis of the architecture document: the **LLM Patient Role Design** is now our core differentiator (per the domain-expert meeting — the market is validated, so quality of execution is what matters). It deserves its own top-level section in `docs/architecture/system-architecture.md`, owned by Aizat, that a reviewer can read as evidence for the proposal's differentiator claim.
+
+This issue is scoped to that section only. General architecture-doc cleanup (nginx removal, qa-rev3 cross-references, formal diagram-type naming) is a separate issue owned by Ilnar (see issue #11).
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Add a new top-level section **"LLM Patient Role Design"** to `system-architecture.md`.
+- [ ] Cover the four behaviours:
+    - **Lying** — partial-recall vs deliberate-concealment prompt patterns.
+    - **Forgetting** — turn-count triggered state degradation.
+    - **Emotions** — tone modulation grounded in the case persona.
+    - **State management** — how per-turn state is fed back into the prompt.
+- [ ] For each behaviour, include either a short prompt-pattern example or a link to the corresponding subsection of `docs/proposal/patient-role-research.md` (issue #9).
+- [ ] Cross-link the new section from the "Architectural principles" list ("LLM Patient Role Design is the primary differentiator — see §…").
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] `system-architecture.md` contains an "LLM Patient Role Design" top-level section covering lying / forgetting / emotions / state management.
+- [ ] Each of the four behaviours has either an inline example or a link into `docs/proposal/patient-role-research.md`.
+- [ ] The section is referenced from the "Architectural principles" list.
+- [ ] The three existing diagrams still render correctly on the docs site after the edit.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-06-update-configuration-management.md
+++ b/docs/project management/pivot-startup-proposal/issue-06-update-configuration-management.md
@@ -1,0 +1,32 @@
+**Owner:** Karim (`GrandAdmiralBee`) &nbsp;·&nbsp; **Labels:** `documentation`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+`docs/cm/configuration-management.md` currently defines a six-level hierarchy (Product Overview → QA → Architecture → Epic → Task → Branch) that made sense when the deliverable was a product. Under the pivot, the "source of truth" chain is different: it starts with the **goal statement** and passes through **user/expert insights**, **hypotheses**, **issues**, and **prototype versions**. Insights and hypotheses are first-class artifacts now — currently they have no home in the CM policy.
+
+Rewrite the artifact hierarchy to the new Level 1–5 structure and add **User Insight** as a first-class artifact type, with a fixed template so every interview and corridor test produces a comparable record. Change triggers must also be updated: the ripple no longer starts with a customer requirement change — it starts with a new user or expert insight.
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Rewrite section 1 ("Hierarchy of Artifacts") to the new five levels:
+    - L1 Goal statement.
+    - L2 Expert meeting notes + user interview summaries.
+    - L3 Hypothesis per prototype iteration + Value Proposition Canvas.
+    - L4 GitHub Issues (research + prototype tasks).
+    - L5 Prototype version + validation results.
+- [ ] Update section 4 ("Impact Ripple") — trigger is now a new user or expert insight (Alina writes summary → Karim opens/updates issues → team updates prototype → Karim validates against hypothesis DoD).
+- [ ] Add a new section **"User Insight artifact type"** with a fixed template: date, participant (anonymised handle), method (interview / corridor test / expert session), key insights (bulleted), linked hypothesis, follow-up issues.
+- [ ] Update the QA revision policy to reference qa-rev4 (once issue #4 lands) — leave a placeholder line if that issue is not yet resolved.
+- [ ] Remove references to "customer meeting" as the change trigger; replace with "user or expert session".
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] Artifact hierarchy has exactly five levels and matches the pivot document.
+- [ ] "User Insight" section includes a copy-pasteable template with all five fields (date / participant / method / insights / linked hypothesis).
+- [ ] Change-trigger workflow starts with a user or expert insight, not a customer meeting.
+- [ ] All references to "Level 6 Git Branches & Commits" are either removed or renumbered — the new hierarchy stops at L5 (prototype version).
+- [ ] Doc renders cleanly on the docs site.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-07-update-cicd-doc.md
+++ b/docs/project management/pivot-startup-proposal/issue-07-update-cicd-doc.md
@@ -1,0 +1,27 @@
+**Owner:** Ilnar (`ilnarkhasanov`) &nbsp;·&nbsp; **Labels:** `documentation`, `component: backend`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+The CI/CD pipeline description (currently spread across `docs/README.md`, sprint overviews, and the QA doc's changelog — there is no single source doc yet) is framed around **production readiness**: load testing, SAST, coverage gates, deployment automation. Under the pivot, the pipeline's job is different — its goal is **demo stability**. A prototype iteration needs to be reproducibly runnable during a mentor demo or a corridor-test session; nothing more.
+
+Create a single CI/CD document under `docs/cicd/pipeline.md` that describes the *current* pipeline (Ruff, MyPy, pytest, `flutter analyze`), reframes its purpose as demo stability, drops load-testing and SAST as mandatory gates for prototype iterations, and adds **prototype version tagging** (`P1-tag`, `P2-tag`, `P3-tag`) so each hypothesis test is reproducible from a specific commit.
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Create `docs/cicd/pipeline.md` (with a matching `docs/cicd/index.md` if the docs site's Jekyll nav needs it).
+- [ ] Document the current pipeline: Ruff → MyPy → pytest → `flutter analyze` → build docker images. Cite the workflow files under `.github/workflows/` by name.
+- [ ] Add a **"Pipeline goal"** section: demo stability, not production readiness. State explicitly that load testing and SAST are optional for prototype iterations and only required if the proposal makes a specific claim that needs that evidence.
+- [ ] Add a **"Prototype tagging"** section: after each iteration, tag the commit that was used for the validation demo as `P1-tag` / `P2-tag` / `P3-tag`. Store the corresponding validation artifact (expert rating, corridor-test findings) linked from `docs/proposal/hypotheses.md`.
+- [ ] Cross-reference from `docs/README.md` and from qa-rev4 (once issue #4 lands).
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] `docs/cicd/pipeline.md` exists and documents the actual current pipeline.
+- [ ] "Pipeline goal" section explicitly says "demo stability, not production readiness".
+- [ ] Load testing and SAST are documented as optional for prototype iterations, with a rationale.
+- [ ] Prototype tagging convention is defined (`P1-tag`, `P2-tag`, `P3-tag`) and links from tag to validation artifact are described.
+- [ ] `docs/README.md` links to the new CI/CD doc.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-08-create-hypotheses-doc.md
+++ b/docs/project management/pivot-startup-proposal/issue-08-create-hypotheses-doc.md
@@ -1,0 +1,30 @@
+**Owner:** Karim (`GrandAdmiralBee`) &nbsp;·&nbsp; **Labels:** `documentation`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+The proposal's credibility rests on three hypotheses (P1 Patient Role, P2 Case System, P3 Full Loop) being explicitly tested against evidence rather than assumed. There is currently no single document that tracks which hypothesis is open, which is confirmed, which is refuted, and where the supporting evidence lives. Without it, the proposal's claims can drift away from what we actually validated.
+
+Create `docs/proposal/hypotheses.md` as the **living hypothesis tracker**. It is the single place where a reviewer can see the state of each hypothesis and follow a link to the artifact that closed it (expert rating for P1, corridor-test transcript for P2, user feedback session for P3). This document is referenced by strategic planning (issue #2), tactical planning (issue #3), QA (issue #4), and CM (issue #6).
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Create `docs/proposal/hypotheses.md` with a fixed-schema table: hypothesis ID, statement, iteration (P1/P2/P3), owner, validation method, current status (open / confirmed / refuted), evidence artifact link.
+- [ ] Pre-populate three rows:
+    - **H1** — LLM can convincingly simulate lying, forgetting, and emotional states. Owner: Aizat. Validation: expert rates believability ≥ 4/5.
+    - **H2** — A constrained test budget changes how learners reason. Owner: Ilnar + Timur. Validation: corridor test — user completes P2 case unassisted.
+    - **H3** — The complete flow feels like a game, not a form. Owner: all. Validation: user feedback session + Alina's interview summary.
+- [ ] Add a **"How to close a hypothesis"** subsection: who decides (Karim + owner), what evidence is required, where the evidence is linked from.
+- [ ] Add a **Changelog** table (mirroring `docs/qa/qa-rev*.md` style) so status transitions are traceable.
+- [ ] Register the doc in the Jekyll nav (`docs/proposal/index.md` with `has_children: true` if that pattern is used site-wide).
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] `docs/proposal/hypotheses.md` exists with all three hypotheses pre-populated.
+- [ ] Each row has an owner and a validation method; status starts at "open".
+- [ ] "How to close a hypothesis" section defines decision-maker and required evidence.
+- [ ] Changelog table exists and is empty (ready for first entry).
+- [ ] Doc appears in the site nav under a "Proposal" section.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-09-create-patient-role-research-doc.md
+++ b/docs/project management/pivot-startup-proposal/issue-09-create-patient-role-research-doc.md
@@ -1,0 +1,31 @@
+**Owner:** Aizat (`muitiiifruckt`) &nbsp;·&nbsp; **Labels:** `documentation`, `component: ai`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+The domain-expert meeting confirmed that similar clinical-training platforms already exist, so the proposal's differentiator is **quality of execution of the LLM patient role** — specifically, believable lying, forgetting, emotional states, and hesitation. This is exactly the P1 hypothesis and Aizat's owned area. Right now the research is scattered across chat, scratch prompts, and personal notes.
+
+Create `docs/proposal/patient-role-research.md` as the consolidated record of what prompt strategies work, what doesn't, and what we recommend for the production system. This document feeds two other artifacts: the LLM Patient Role Design section of the architecture doc (issue #5) and the differentiator claims in `technical-product-description.md` (issue #1). If those claims aren't backed by evidence here, they don't belong in the proposal.
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Create `docs/proposal/patient-role-research.md` with the following top-level sections:
+    - **Scope** — what the research covers and what it deliberately excludes.
+    - **Method** — models tested, prompt-strategy variants, evaluation setup (expert rater, believability rubric).
+    - **Findings per behaviour** — one subsection each for lying, forgetting, emotional states, hesitation. Every subsection: what worked, what didn't, example prompts, believability rating.
+    - **Recommendations for production** — the prompt patterns we'd carry forward if the proposal is accepted.
+    - **Open questions** — behaviours we couldn't validate in-scope.
+- [ ] For each finding, include either (a) a rater score from the expert session or (b) an explicit note that the finding is preliminary and needs validation.
+- [ ] Cross-link from the architecture doc's "LLM Patient Role Design" section (issue #5) and from the H1 row in `docs/proposal/hypotheses.md` (issue #8).
+- [ ] Register in the Jekyll nav under "Proposal" (same section as hypotheses.md).
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] `docs/proposal/patient-role-research.md` exists with all five top-level sections.
+- [ ] Each of the four behaviours (lying / forgetting / emotional states / hesitation) has its own findings subsection.
+- [ ] Every finding is either backed by an expert rating or explicitly marked "preliminary — needs validation".
+- [ ] "Recommendations for production" section names concrete prompt patterns, not vague guidance.
+- [ ] Doc is linked from the architecture doc and from `hypotheses.md`.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-10-create-user-insights-doc.md
+++ b/docs/project management/pivot-startup-proposal/issue-10-create-user-insights-doc.md
@@ -1,0 +1,34 @@
+**Owner:** Alina (`rayderdo`) &nbsp;·&nbsp; **Labels:** `documentation`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+Under the pivot, user interviews and corridor tests are our primary evidence source — but only if the findings are captured in a comparable, structured way. If each interview lives in a separate Google doc with its own format, the proposal can't cite them consistently and the CM policy (issue #6) can't treat "User Insight" as a first-class artifact.
+
+Create `docs/proposal/user-insights.md` as the running log. Every entry follows a fixed structure so that a reviewer can scan the log linearly, and so that any insight can be traced to the hypothesis it advances. This document is the L2 artifact referenced by the new CM hierarchy (issue #6) and by the H2 / H3 rows in `hypotheses.md` (issue #8).
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Create `docs/proposal/user-insights.md` with an intro that names it as the L2 artifact and links to `docs/cm/configuration-management.md`.
+- [ ] Define a **fixed per-entry template**:
+    - `date` (ISO)
+    - `participant` (anonymised handle — e.g. `P-01`, `P-02`)
+    - `method` (interview / corridor test / expert session)
+    - `context` (one line: what the participant was shown or asked)
+    - `key insights` (bulleted, ≤ 5 items)
+    - `linked hypothesis` (H1 / H2 / H3 or "none")
+    - `follow-up issues` (list of GitHub issue links, or "none yet")
+- [ ] Add one worked example entry so the format is unambiguous for future logging.
+- [ ] Add an anonymisation guideline: no names, no institution names, no clinical specialty combined with location.
+- [ ] Register in Jekyll nav under "Proposal".
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] `docs/proposal/user-insights.md` exists with the fixed per-entry template documented.
+- [ ] All seven fields (date, participant, method, context, insights, linked hypothesis, follow-up issues) are named in the template.
+- [ ] One worked example entry demonstrates the format.
+- [ ] Anonymisation guideline is present and enforceable (a reviewer can tell whether a future entry violates it).
+- [ ] Doc is discoverable from the site nav under "Proposal".
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-11-architecture-doc-cleanup.md
+++ b/docs/project management/pivot-startup-proposal/issue-11-architecture-doc-cleanup.md
@@ -1,0 +1,31 @@
+**Owner:** Ilnar (`ilnarkhasanov`) &nbsp;·&nbsp; **Labels:** `documentation`, `component: backend`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+`docs/architecture/system-architecture.md` has already been partially updated for the prototype scope: nginx is out of the main diagrams and each diagram has a type label (Diagram 1 — Static component view, Diagram 2 — Dynamic session flow, Diagram 3 — Deployment view). What is still missing is a sweep for consistency with the current QA revision, plus a formal diagram-notation reference so mentors don't have to ask "what kind of diagram is this?" during the demo.
+
+This issue covers three cleanup passes: (a) remove any remaining nginx references outside the main diagrams (integration notes, sprint docs, README fragments), (b) cross-link every architectural claim to the current `qa-rev3.md`, and (c) attach an explicit notation reference to each diagram (which UML/C4/mermaid family it belongs to) so a reviewer can name what they are looking at without asking.
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Sweep the whole `docs/` tree for `nginx` references (`grep -r nginx docs/`) and remove anything left over from the pre-pivot deployment view — including in `docs/integrations/`, sprint overviews, and `docs/README.md`. Any nginx config that must persist for developer reference moves into a separate `docs/architecture/deployment-notes.md` and is called out as "developer-only, not part of the proposal view".
+- [ ] Add a **"QA compliance"** subsection to `system-architecture.md` that lists which QA-rev3 attributes each architectural decision satisfies (e.g. AIProvider abstraction → QA-ARCH-01, action_logs → QA-ARCH-02, mock LLM → QA-REPRO-02). Every bullet links to the corresponding line in `docs/qa/qa-rev3.md`.
+- [ ] Under each of the three diagrams, add a one-line **notation** tag naming the diagram family concretely — for example:
+    - Diagram 1: "C4 model, Level 2 (Container diagram) rendered with mermaid `flowchart TB`."
+    - Diagram 2: "UML sequence diagram rendered with mermaid `sequenceDiagram`."
+    - Diagram 3: "UML deployment diagram rendered with mermaid `flowchart LR`."
+- [ ] Add a short **"Diagram legend"** section at the top of the doc explaining what a container / sequence / deployment diagram *is* and what it *isn't*, so a reviewer can map them to standard notation without asking.
+- [ ] Verify the doc still renders on the Jekyll site (`bundle exec jekyll build` locally or a preview PR).
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] `grep -ri nginx docs/` returns nothing except an intentional mention in `deployment-notes.md` (if that file is kept).
+- [ ] `system-architecture.md` has a "QA compliance" subsection with at least one QA-rev3 reference per architectural decision.
+- [ ] Each of the three diagrams has an explicit notation tag naming its family (container / sequence / deployment).
+- [ ] A "Diagram legend" section explains the three notations in one paragraph each.
+- [ ] Jekyll build succeeds; no broken internal links.
+- [ ] Does not touch the LLM Patient Role Design section (that is issue #5's scope).
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/pivot-startup-proposal/issue-12-online-docs-cleanup.md
+++ b/docs/project management/pivot-startup-proposal/issue-12-online-docs-cleanup.md
@@ -1,0 +1,32 @@
+**Owner:** Karim (`GrandAdmiralBee`) &nbsp;·&nbsp; **Labels:** `documentation`
+
+### <h2> Task Description & Context <a id="task-description-and-context" href="#task-description-and-context">🔗</a> </h2>
+
+The published docs site (`https://virtual-ai-patient.github.io/platform`) currently mixes documents written under the **old goal** (medical training product for a customer) with documents written under the **new goal** (startup proposal). Right now a mentor or reviewer opening the site can't tell at a glance which docs still apply and which are historical — the nav is flat and the old artefacts (market assessment, pilot-oriented product description, old QA revisions, epic-driven strategic plan) sit next to the current ones.
+
+Restructure the online docs so the pivot is visible on the landing page. Two top-level sections: **"Current — Startup Proposal (post-pivot)"** and **"Historical — Product for Customer (pre-pivot)"**, each with its own sub-nav. Historical documents are not deleted — they stay reachable, but under an explicit "historical" bucket so nobody accidentally cites them as current. A short note at the top of the landing page explains the pivot in two sentences and points to the current section.
+
+### <h2> Subtasks <a id="subtasks" href="#subtasks">🔗</a> </h2>
+
+- [ ] Rewrite `docs/index.md` (landing page): a two-paragraph intro naming the pivot (old goal → new goal), then two clearly labelled sections — **"Current — Startup Proposal"** and **"Historical — Product for Customer"** — each with a linked list of documents in that bucket.
+- [ ] Audit every doc under `docs/` and assign it to one bucket:
+    - **Current:** qa-rev3 (and rev4 once it lands), current `system-architecture.md`, `technical-product-description.md` (after issue #1 lands), pivoted planning docs, everything under `docs/proposal/`, current sprint, `cm/`, `cicd/` (once issue #7 lands).
+    - **Historical:** qa-rev1, qa-rev2, `docs/market/market-assessment.md`, pre-pivot sprint overviews (sprint01–05), any epic/roadmap references to the discontinued 5-month product timeline, integration notes tied to Third Opinion.
+- [ ] Update the Jekyll nav (`_config.yml` and per-file `parent:` / `nav_order:` frontmatter) so the two buckets are the top-level nav entries, and each historical doc has a visible "**Historical (pre-pivot)**" badge in its title.
+- [ ] Add a short **"About the pivot"** page (`docs/about-the-pivot.md`) that explains the goal change, links to the pivot planning document, and is reachable from both buckets.
+- [ ] Verify all internal links after the reorg (`bundle exec jekyll build --strict-front-matter` or a link checker) — any doc referencing a moved page must be updated.
+- [ ] Post a short note in `#docs` / team chat once the site is republished so the team stops citing historical docs by accident.
+
+### <h2> Task Acceptance Criteria <a id="task-acceptance-criteria" href="#task-acceptance-criteria">🔗</a> </h2>
+
+- [ ] Landing page opens with a two-paragraph explanation of the pivot.
+- [ ] Nav has exactly two top-level buckets: **Current — Startup Proposal** and **Historical — Product for Customer**.
+- [ ] Every document under `docs/` is assigned to exactly one bucket; nothing is orphaned.
+- [ ] Every historical page shows a visible "**Historical (pre-pivot)**" badge in its title or top-of-page banner.
+- [ ] `docs/about-the-pivot.md` exists and is linked from both buckets.
+- [ ] Jekyll build succeeds with no broken internal links.
+- [ ] Old QA revisions (rev1, rev2) remain reachable — nothing is deleted, only reorganised.
+
+### <h2> Sub-issues <a id="sub-issues" href="#sub-issues">🔗</a> </h2>
+
+Sub-issues are blockers for this task.

--- a/docs/project management/strategic-planning-rev1.md
+++ b/docs/project management/strategic-planning-rev1.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: Strategic Planning — Rev 1 (Historical)
+parent: Strategic Planning
+grand_parent: Current — Startup Proposal
+nav_order: 1
+---
+
 # Strategic Planning — Revision 1 (pre-pivot)
 
 > **Historical document.** This revision was written at project kickoff when the

--- a/docs/project management/strategic-planning-rev2.md
+++ b/docs/project management/strategic-planning-rev2.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: Strategic Planning — Rev 2 (Current)
+parent: Strategic Planning
+grand_parent: Current — Startup Proposal
+nav_order: 2
+---
+
 # Strategic Planning — Revision 2 (post-pivot: startup proposal)
 
 > **[RETROSPECTIVE — Written July 2026]** This document describes the strategic plan as we believe it *should have been* defined from the start of the pivot in March 2026. In practice the project did not follow this framework from day one — this is our honest reconstruction of the correct approach, written for the startup proposal. See [About the Pivot](../about-the-pivot.md).

--- a/docs/project management/tactical-planning-rev1.md
+++ b/docs/project management/tactical-planning-rev1.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: Tactical Planning — Rev 1 (Historical)
+parent: Tactical Planning
+grand_parent: Current — Startup Proposal
+nav_order: 1
+---
+
 # Tactical Planning — Rev 1 (Historical)
 
 > **[HISTORICAL — Pre-pivot, March 2026]**

--- a/docs/project management/tactical-planning-rev2.md
+++ b/docs/project management/tactical-planning-rev2.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: Tactical Planning — Rev 2 (Current)
+parent: Tactical Planning
+grand_parent: Current — Startup Proposal
+nav_order: 2
+---
+
 # Tactical Planning — Rev 2
 
 > **[RETROSPECTIVE — Written July 2026]** This document describes the tactical process as we believe it *should have been* run from the start of the pivot. In practice the team did not operate by this cycle initially — this is our honest reconstruction of the correct approach, written for the startup proposal. See [About the Pivot](../about-the-pivot.md).

--- a/docs/research/ai-patient-experimental-verification.md
+++ b/docs/research/ai-patient-experimental-verification.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: Experimental verification protocol (rev1)
+parent: Proposal
+grand_parent: Current — Startup Proposal
+nav_order: 11
+nav_exclude: true
+---
+
 # Экспериментальная верификация поведения виртуального пациента (Anthropic API)
 
 ## Назначение документа

--- a/docs/research/ai-patient-problems-and-mitigations.md
+++ b/docs/research/ai-patient-problems-and-mitigations.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: LLM failure classes and mitigations (rev1)
+parent: Proposal
+grand_parent: Current — Startup Proposal
+nav_order: 10
+nav_exclude: true
+---
+
 # Сбои поведения LLM в роли виртуального пациента: классификация и меры
 
 ## Назначение документа


### PR DESCRIPTION
All pages that appeared unorganised in the sidebar are now assigned:
- CM rev1 / rev2: parent = Configuration Management
- Strategic planning rev1 / rev2: parent = Strategic Planning
- Tactical planning rev1 / rev2: parent = Tactical Planning
- Research rev1 docs (problems, verification): nav_exclude = true (reachable via links from patient-role-research.md)
- Cases and clinical-case-format: nav_exclude = true

_config.yml exclude list added for task board directories (epic-*, feature-*, pivot-startup-proposal) — those are GitHub Issues content, not web pages; excluded from Jekyll build entirely.