### PR TITLE
planning: Rev 3 parallel-track strategy and sprint model

### DIFF
--- a/docs/project management/strategic-planning-rev3.md
+++ b/docs/project management/strategic-planning-rev3.md
@@ -1,0 +1,227 @@
+---
+layout: default
+title: Strategic Planning — Rev 3 (Current)
+parent: Strategic Planning
+grand_parent: Current — Startup Proposal
+nav_order: 3
+---
+
+# Strategic Planning — Revision 3 (parallel tracks)
+
+**Goal:** Deliver a startup proposal backed by a validated prototype.
+**Active since:** July 2026
+**Supersedes:** [strategic-planning-rev2.md](strategic-planning-rev2.md) (sequential P1→P2→P3)
+**Traceability:** [tactical-planning-rev3.md](tactical-planning-rev3.md) · [hypotheses.md](../proposal/hypotheses.md) · [configuration-management-rev2.md](../cm/configuration-management-rev2.md)
+
+---
+
+## 1. What is Strategic Planning?
+
+Strategic planning defines our **vision, tracks, and success criteria** over the project timeline. It answers:
+
+- **What** are we delivering by August 2026?
+- **How** do tracks run in parallel and converge?
+- **How** do we know each hypothesis is closed?
+- **Who** owns each track?
+
+---
+
+## 2. Goal (unchanged)
+
+In early 2026 the team's engagement with the original industry partner (Third Opinion) did not progress to a signed agreement. The team pivoted to:
+
+> **Deliver a startup proposal for an AI-powered clinical training simulator, backed by a validated prototype.**
+
+The proposal must demonstrate three things:
+
+1. The **LLM patient role** is the core differentiator — believable lying, forgetting, emotional states, and hesitation.
+2. A **structured case system** with constrained resources changes how learners reason.
+3. The combined experience feels like a **game**, not a form.
+
+*Scope boundary:* Business model, go-to-market strategy, and funding ask are explicitly out of scope for this SE course project.
+
+---
+
+## 3. Why Parallel Tracks (Rev 3 change)
+
+Rev 2 used a sequential structure: close P1 before starting P2, close P2 before starting P3. This was conservative. With limited time remaining, the dependency analysis shows that H1, H2, and H3 can run simultaneously:
+
+| Hypothesis | Needs from others | Can start without |
+| :--- | :--- | :--- |
+| H1 — Patient Role (Aizat) | Nothing | Any UI — console input is enough for expert rating |
+| H2 — Case System (Ilnar) | Nothing | H1 can be a mock patient during development |
+| H3 — Game Feel (Timur) | H2 backend for **final validation only** | Game design + mock UI start immediately; switch to real backend when H2 is ready |
+| Track D — Recruitment (Alina) | Nothing | Independent from day one |
+
+**Only one hard dependency:** H3 final validation requires H2 budget system to be working. H3 research and game design are fully independent.
+
+---
+
+## 4. Four Parallel Tracks
+
+```text
+Sprint 1          Sprint 2          Sprint 3          Finalisation
+────────────────────────────────────────────────────────────────────
+Track A — Aizat
+  [Prompt design] → [Expert session] → [Close H1] ─────────────────┐
+                                                                     │
+Track B — Ilnar                                                      │
+  [Budget system] → [Corridor test] → [Close H2] ───────────────────┤
+                                                                     │
+Track C — Timur                                                      │
+  [Game design]   → [Mock UI + H3]  → [Real backend] → [Close H3] ──┤
+               ↑ H2 backend ready ──────────────────┘               │
+                                                                     ▼
+Track D — Alina                                              Proposal
+  [Recruit H1 expert] → [Recruit H2/H3 participants] ──────> Finalisation
+                                                             Sprint
+────────────────────────────────────────────────────────────────────
+```
+
+### Track A — Patient Role (H1 owner: Aizat)
+
+**Goal:** Prove that an LLM can convincingly simulate lying, forgetting, and emotional states.
+
+| Stage | Output | Exit criterion |
+| :--- | :--- | :--- |
+| Prompt design | Prompt variants for all 5 rubric dimensions | Automated harness passes for dimensions 1–3; dimensions 4–5 have prompt strategy |
+| Expert session | L2 artifact in `user-insights.md` | Session conducted; raw notes committed same day |
+| Validation | H1 closed | Expert rating ≥ 4/5 on all 5 dimensions; `hypotheses.md` updated; `P1-tag` on commit |
+
+**Entry:** Seed case available (already satisfied).
+**Exit (H1 closed):** As defined in `hypotheses.md`.
+
+---
+
+### Track B — Case System (H2 owner: Ilnar)
+
+**Goal:** Prove that a constrained investigation budget changes how learners reason.
+
+| Stage | Output | Exit criterion |
+| :--- | :--- | :--- |
+| Budget system | Working backend with price catalog and per-session counter | `docker compose up` passes QA-REPRO-01/02/03 |
+| Corridor test | ≥ 3 participants complete case without assistance | Observers record budget-driven strategy changes |
+| Validation | H2 closed | Findings in `user-insights.md`; H2 status updated; `P2-tag` on commit |
+
+**Entry:** Independent — starts sprint 1.
+**Exit (H2 closed):** As defined in `hypotheses.md`. Also unblocks Track C final validation.
+
+---
+
+### Track C — Game Feel (H3 owner: Timur)
+
+**Goal:** Prove that the full loop (conversation → tests → diagnosis → debrief) feels like a game.
+
+Track C has two phases with a hard switch point:
+
+| Phase | Depends on | Output |
+| :--- | :--- | :--- |
+| Game design + mock UI | Nothing | Interview ≥ 2 users on game mechanics concept; build mock UI for H3 sessions |
+| Switch to real backend | H2 backend ready (Track B) | Integrate real budget system; run H3 validation sessions |
+| Validation | H2 closed | ≥ 5 participants; H3 closed; `P3-tag` on commit |
+
+**Hard switch date:** Agreed at sprint 2 Monday planning once H2 backend is confirmed ready.
+**Entry:** Game design starts sprint 1 on mock. Final validation unblocks only after H2 closes.
+**Exit (H3 closed):** As defined in `hypotheses.md`.
+
+---
+
+### Track D — Recruitment and L2 Artifacts (owner: Alina)
+
+**Goal:** Ensure participants are available for every session across all three tracks.
+
+| Responsibility | Notes |
+| :--- | :--- |
+| Recruit H1 domain expert | Hardest to recruit — start in sprint 1, week 1 |
+| Recruit H2/H3 corridor-test participants | Can draw from same pool; minimum 3 for H2, 5 for H3 |
+| Facilitate sessions | One facilitator per session; note-taker assigned per session |
+| Commit L2 artifacts | Same day as session; template from configuration-management-rev2 |
+
+Alina is not the sole note-taker — each track owner may take notes for their own session with Alina facilitating. Any arrangement that gets the L2 artifact committed same day is acceptable.
+
+---
+
+## 5. Integration Point — Proposal Finalisation
+
+When **all three hypotheses are explicitly closed** (confirmed or refuted), Karim calls a Proposal Finalisation sprint:
+
+- Every claim in the proposal links to a Level 2 artifact. No unvalidated assertions.
+- `docs/architecture/system-architecture.md` reflects the current state of the prototype.
+- `docs/proposal/hypotheses.md` shows status for all three hypotheses.
+- Pitch deck references all three tracks with their validation outcomes.
+- Repository passes `docker compose up` from a fresh clone; reviewer can reach a working demo in ≤ 10 minutes (QA-DOC-01).
+
+A refuted hypothesis is **not a blocker** for finalisation — it must be documented and acknowledged in the pitch, not hidden.
+
+---
+
+## 6. Milestones
+
+| Milestone | Target | Exit criterion | Owner |
+| :--- | :--- | :--- | :--- |
+| Discovery complete | March 2026 ✓ | Expert sessions done; 3 hypotheses open | Alina |
+| All tracks started | Sprint 1 (late July 2026) | Issues open per track; Alina recruiting | All |
+| H1 closed | August 2026 | Expert rating recorded; `P1-tag` | Aizat |
+| H2 closed | August 2026 | ≥ 3 corridor tests; `P2-tag` | Ilnar |
+| H3 closed | August 2026 | ≥ 5 sessions; `P3-tag` | Timur |
+| **All hypotheses closed** | August 2026 | All three statuses set in `hypotheses.md` | Karim |
+| Proposal ready | August 2026 | All claims traceable; demo runs from cold clone | Karim |
+| Pitch | August 2026 | Delivered to course jury / IU | All |
+
+The "All hypotheses closed" milestone replaces "P3 validated" from Rev 2. Hypotheses close independently — H1 may close before H2 or H3.
+
+---
+
+## 7. Risks and Mitigations
+
+Risks inherited from Rev 2 plus parallel-specific additions.
+
+| Risk | Probability | Impact | Mitigation |
+| :--- | :--- | :--- | :--- |
+| Hypothesis refuted with no time to iterate | Medium | High | Each track closes by its own milestone date. Refutation is recorded and used as evidence — do not retry indefinitely. |
+| Alina recruiting for 3 tracks simultaneously | High | High | Prioritise H1 expert first (hardest to recruit); H2 and H3 corridor tests can draw from the same participant pool. |
+| H3 blocked waiting for H2 backend | Medium | Medium | Timur works on mock UI and game design until H2 is confirmed ready; hard switch date agreed at sprint 2 planning. |
+| Wednesday sync becomes 3 parallel monologues | Medium | Medium | 15 min per track (capped); every 2nd Wednesday is a full integration review — do the three tracks still tell a coherent proposal story? |
+| Coordination overhead slows all tracks | Medium | Medium | Karim owns cross-track dependencies; any blocker raised by Wednesday, resolved before Thursday. |
+| Proposal claim not traceable to evidence | Medium | High | Karim runs traceability audit before Proposal Finalisation sprint. |
+| Demo crashes during pitch | Low | High | Tag commit frozen and smoke-tested the day before pitch; no hotfixes on pitch day. |
+
+---
+
+## 8. Team Roles
+
+| Person | Track | Strategic responsibility |
+| :--- | :--- | :--- |
+| Aizat | A — H1 | Prompt design, automated harness, expert session, H1 closure |
+| Ilnar | B — H2 | Backend budget system, corridor test facilitation, H2 closure |
+| Timur | C — H3 | Game design, mock UI, switch to real backend, H3 closure |
+| Alina | D — Recruitment | Participant pipeline across all tracks, L2 artifacts, proposal narrative |
+| Karim | Cross-track | Sprint planning, dependency resolution, traceability audit, milestone validation |
+
+---
+
+## 9. Connection to Other Documents
+
+```text
+Strategic Plan Rev 3 (this document — tracks + milestones)
+    ↓
+docs/proposal/hypotheses.md  ←  status of H1 / H2 / H3 (per-track)
+    ↓
+Tactical Planning Rev 3  ←  per-track sprint goals and cross-track sync
+    ↓
+GitHub Issues  ←  atomic tasks with AC linked to hypothesis and track
+    ↓
+Prototype tags  ←  P1-tag / P2-tag / P3-tag (independent per track)
+    ↓
+docs/proposal/user-insights.md  ←  evidence that closes each hypothesis
+```
+
+---
+
+## Changelog
+
+| Date | Author | Changes |
+| :--- | :--- | :--- |
+| July 2026 | Karim Abdulkin | **Rev 3:** replaced sequential P1→P2→P3 phases with four parallel tracks (A/B/C/D). Single hard dependency retained: H3 final validation requires H2 backend. Added parallel-specific risks. "All hypotheses closed" milestone replaces "P3 validated". Goal statement, hypotheses, team roles, and traceability hierarchy preserved unchanged. |
+| July 2026 | Karim Abdulkin | Rev 2: hypothesis-driven phases replacing 5-month feature roadmap. |
+| March 2026 | Karim Abdulkin | Initial post-pivot plan. |

--- a/docs/project management/tactical-planning-rev3.md
+++ b/docs/project management/tactical-planning-rev3.md
@@ -1,0 +1,279 @@
+---
+layout: default
+title: Tactical Planning — Rev 3 (Current)
+parent: Tactical Planning
+grand_parent: Current — Startup Proposal
+nav_order: 3
+---
+
+# Tactical Planning — Rev 3
+
+**Goal:** Deliver a startup proposal backed by a validated prototype.
+**Active since:** July 2026
+**Supersedes:** [tactical-planning-rev2.md](tactical-planning-rev2.md) (single-hypothesis-per-sprint model)
+**Traceability:** [strategic-planning-rev3.md](strategic-planning-rev3.md) · [hypotheses.md](../proposal/hypotheses.md) · [configuration-management-rev2.md](../cm/configuration-management-rev2.md)
+
+---
+
+## 1. What Changed and Why
+
+Rev 2 ran one hypothesis per sprint: the whole team focused on H1 until it closed, then H2, then H3. With limited time remaining, the dependency analysis in [strategic-planning-rev3.md](strategic-planning-rev3.md) shows H1, H2, and H3 can run simultaneously. Rev 3 restructures the sprint to manage four parallel tracks.
+
+| Rev 2 focus | Rev 3 focus |
+| :--- | :--- |
+| One active hypothesis per sprint | Three hypotheses active simultaneously across four tracks |
+| Sprint goal = advance active hypothesis | Sprint goal = advance **each track's** hypothesis |
+| Monday planning: one team, one hypothesis | Monday planning: one goal stated per track owner |
+| Wednesday sync: joint status | Wednesday sync: 15 min per track; full integration every 2nd week |
+| Denis sees one hypothesis at Thursday | Denis sees all three tracks at Thursday |
+
+Everything else is preserved: 2-week sprint, Mon/Wed/Thu rhythm, DoD requiring hypothesis to advance, and the hypothesis closure ritual.
+
+---
+
+## 2. Four Tracks
+
+| Track | Owner | Hypothesis | Running condition |
+| :--- | :--- | :--- | :--- |
+| A | Aizat | H1 — Patient Role | Starts sprint 1; independent |
+| B | Ilnar | H2 — Case System | Starts sprint 1; independent |
+| C | Timur | H3 — Game Feel | Game design starts sprint 1; final validation unblocks after H2 ready |
+| D | Alina | Recruitment + L2 artifacts | Starts sprint 1; serves all three tracks |
+
+---
+
+## 3. Two-Week Sprint Rhythm
+
+The 2-week structure is unchanged. What changes is that sprint events now happen **per track**, not for the team as a single unit.
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│  WEEK 1                                                          │
+│                                                                  │
+│  [Monday W1] — Sprint Planning (per track)                       │
+│  Each track owner states:                                        │
+│    • Track goal this sprint                                      │
+│    • Dependencies needed from other tracks                       │
+│    • Is recruitment on track for my session this sprint?         │
+│  Karim: resolve any cross-track blockers before the session week │
+│                                                                  │
+│            ↓                                                     │
+│                                                                  │
+│  [Wednesday W1] — Per-Track Sync (15 min per track, capped)     │
+│    A: Aizat — H1 progress, blocker, what's needed from D        │
+│    B: Ilnar — H2 progress, blocker, what's needed from D        │
+│    C: Timur — H3/game design progress, H2 dependency status     │
+│    D: Alina — participant pipeline status for each track         │
+│  Karim resolves cross-track blockers before Thursday             │
+│                                                                  │
+│            ↓                                                     │
+│                                                                  │
+│  [Thursday W1] — Mentor Check-in (light, 30 min)                │
+│  Denis sees status across all three tracks:                      │
+│    • "Here is what we learned / built this week across H1/H2/H3" │
+│    • No go/no-go expected; unblock recruitment or prototype issues│
+│                                                                  │
+│            ↓                                                     │
+│                                                                  │
+│  [Tue–Fri W1, flexible] — Sessions (per track schedule)          │
+│  Each track runs its session when participant is available        │
+│  Tracks may run sessions on different days within the same sprint │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│  WEEK 2                                                          │
+│                                                                  │
+│  [Mon–Wed W2] — L2 Recording + Analysis (per track)             │
+│    • Each track owner drafts and commits L2 artifact same day    │
+│    • Anonymise per guidelines in user-insights.md                │
+│    • Map findings to hypothesis criteria (QA-VAL)                │
+│    • Ship prototype fixes surfaced by the session                │
+│                                                                  │
+│            ↓                                                     │
+│                                                                  │
+│  [Wednesday W2] — Integration Review (every 2nd sprint)          │
+│  Full cross-track review — do H1/H2/H3 tracks still tell a      │
+│  coherent proposal story? Runs instead of standard per-track sync│
+│                                                                  │
+│            ↓                                                     │
+│                                                                  │
+│  [Thursday W2] — Mentor Session — Hypothesis Decisions (50 min)  │
+│  Denis sees findings across all active tracks                    │
+│  Any track that ran a session this sprint presents:              │
+│    • L2 artifact key findings                                    │
+│    • Hypothesis go/no-go if criteria are met                     │
+│  Karim + hypothesis owner decide per track independently         │
+│  Update hypotheses.md live for any track that closes             │
+│                                                                  │
+│            ↓                                                     │
+│                                                                  │
+│  [Friday W2] — Wrap-up                                           │
+│  Close completed issues; carry open items to next sprint         │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Monday Sprint Planning (per track)
+
+**Inputs:**
+- Hypothesis status per track from `hypotheses.md`
+- Action items from previous sprint's Thursday W2 session
+- Participant availability per track — confirm slots before planning ends
+- H2 backend readiness (affects Track C switch date)
+
+**Planning steps:**
+
+| Step | Activity | Tool |
+| :--- | :--- | :--- |
+| 1 | Each track owner states the sprint goal for their track | `hypotheses.md` |
+| 2 | Dependency check: what does each track need from others this sprint? | Verbal; blockers go to GitHub Issues |
+| 3 | Confirm Alina's participant pipeline covers all sessions planned this sprint | Track D status |
+| 4 | Assign facilitator + note-taker per session | GitHub Assignees |
+| 5 | Create or update implementation issues per track; set AC from QA-VAL | GitHub Issues |
+
+**Output:** 3–5 issues per active track, each with owner, AC, and hypothesis link.
+
+---
+
+## 5. Wednesday Sync (per track, 15 min cap)
+
+Each track owner gives a status in this order:
+1. Progress since Monday
+2. Blocker (if any) — name it explicitly; "slow but OK" is not a blocker report
+3. Dependency needed from another track before Thursday
+
+Karim logs cross-track dependencies and resolves them before Thursday.
+
+**Every 2nd Wednesday (Integration Review):**
+All four track owners answer one question: "Do H1, H2, and H3 findings still tell a coherent startup proposal story?" If not, Karim escalates to a proposal-narrative correction before the pitch deck is written.
+
+---
+
+## 6. Thursday Mentor Session Agendas
+
+### Thursday W1 — Check-in (30 min)
+
+Denis sees all three tracks simultaneously. No per-hypothesis deep dive unless requested.
+
+| Time | Activity |
+| :--- | :--- |
+| 5 min per track (15 min total) | Status: is the session scheduled? Any prototype or recruitment blocker? |
+| 10 min | Unblock any cross-track or recruitment issue |
+| 5 min | Adjust sprint scope if participant cancelled or is delayed |
+
+**Output:** Blockers unblocked; sprint scope per track confirmed.
+
+### Thursday W2 — Hypothesis Decisions (50 min)
+
+| Time | Activity |
+| :--- | :--- |
+| 5 min per track (up to 15 min total) | Present L2 artifact key findings for any track that ran a session |
+| 15 min | Map findings to hypothesis criteria (QA-VAL) per track |
+| 10 min | Per-track hypothesis go/no-go decisions |
+| 5 min | Scope and priority adjustments for next sprint (per track) |
+| 5 min | Document action items as GitHub Issues |
+
+**Output:** Updated `hypotheses.md` for any track that closes; ≥1 new or updated GitHub Issue.
+
+---
+
+## 7. Prototype Session Protocol
+
+Unchanged from Rev 2. Applies independently per track.
+
+**Before the session:**
+- Prototype is deployable via `docker compose up` (QA-REPRO-01).
+- Seed case loaded (QA-REPRO-02).
+- Mock LLM enabled if no API key available (QA-REPRO-03).
+- Track C before H2 switch: mock backend is acceptable; document which backend was used in the L2 artifact.
+
+**During the session:**
+- Facilitator runs the participant through the prototype without coaching.
+- Note-taker records raw observations in real time.
+- Session is not recorded without explicit participant consent.
+
+**After the session (same day):**
+- Note-taker drafts the L2 artifact using the template from [configuration-management-rev2.md](../cm/configuration-management-rev2.md).
+- Anonymise per the rules in [user-insights.md](../proposal/user-insights.md).
+- Commit to `docs/proposal/user-insights.md` before end of day.
+- Open follow-up GitHub Issues for findings that affect hypothesis criteria.
+
+---
+
+## 8. Definition of Done (updated)
+
+### Issue-level DoD
+
+An issue is Done only when **both** conditions are true:
+
+| Condition | How to verify |
+| :--- | :--- |
+| Technical AC met | PR merged, tests pass, doc updated |
+| Track advanced | Linked hypothesis status updated in `hypotheses.md`, or a new L2 artifact committed |
+
+If an issue does not touch any hypothesis (e.g. infra fix), the second condition is waived and noted explicitly in the issue.
+
+### Sprint-level DoD (new in Rev 3)
+
+A sprint closes when **all three** conditions are true:
+
+- [ ] Each track has advanced its hypothesis **OR** explicitly documented why it did not (blocker named in a GitHub Issue, not silent)
+- [ ] Any new L2 artifact from sessions committed to `user-insights.md`
+- [ ] Cross-track dependencies updated in `hypotheses.md` (e.g. H2 ready → Track C switch date set)
+
+**A sprint does NOT close if a track is silently stuck.** Blockers must be named.
+
+---
+
+## 9. Hypothesis-Closure Ritual (unchanged, now per track)
+
+A hypothesis is closed only at the **Thursday W2 mentor session**, independently per track. H1 can close while H2 and H3 are still running.
+
+1. Pull up the hypothesis entry in [hypotheses.md](../proposal/hypotheses.md).
+2. Confirm the exit criterion from QA-VAL is met (or clearly not met).
+3. Confirm the supporting L2 artifacts in [user-insights.md](../proposal/user-insights.md) are committed and anonymised.
+4. Karim + hypothesis owner state the verdict aloud.
+5. Update `hypotheses.md` status field in the same session.
+6. If **validated**: open a follow-up issue to incorporate the finding into the proposal deck.
+7. If **refuted**: open a retrospective issue, update `hypotheses.md`, notify Monday planning. Do not silently drop.
+
+**Who decides:** Karim + the track's hypothesis owner. No unilateral closure.
+
+**Proposal finalisation trigger:** When all three hypotheses are explicitly closed (confirmed or refuted), Karim calls a Proposal Finalisation sprint. Refutation does not block finalisation — it must be acknowledged in the pitch.
+
+---
+
+## 10. Handling Hypothesis Refutation (unchanged)
+
+| Step | Action | Owner |
+| :--- | :--- | :--- |
+| 1 | Change status in `hypotheses.md` to `Refuted` with date and evidence reference | Karim |
+| 2 | Open a retrospective GitHub Issue explaining what the evidence showed | Karim + track owner |
+| 3 | Notify Monday planning — adjust that track's scope | Alina (PM) |
+| 4 | Do **not** silently remove the hypothesis — it remains as evidence | All |
+
+Refutation is not failure; it is evidence. The other tracks continue unaffected.
+
+---
+
+## 11. Success Metrics
+
+| Metric | Target | How to measure |
+| :--- | :--- | :--- |
+| L2 artifacts committed same day as session | 100% | Check commit date vs session date |
+| All tracks advance or name a blocker each sprint | Every sprint | Sprint wrap-up review on Friday W2 |
+| Hypothesis status updated at Thursday W2 session | Every session that ran | `hypotheses.md` last-modified date |
+| Issues with QA-VAL AC reference | 100% of hypothesis-linked issues | Issue review at Monday planning |
+| Refuted hypotheses documented | 100% | `hypotheses.md` has no blank status |
+| Integration review held every 2nd sprint | 100% | Wednesday W2 calendar |
+
+---
+
+## Changelog
+
+| Date | Author | Changes |
+| :--- | :--- | :--- |
+| July 2026 | Karim Abdulkin | **Rev 3:** replaced single-hypothesis-per-sprint model with four parallel tracks (A/B/C/D). Monday planning now per-track. Wednesday sync now 15 min per track with full integration review every 2nd sprint. Thursday shows all three tracks to Denis simultaneously. Sprint-level DoD added: track must advance or name blocker explicitly. Hypothesis closure ritual unchanged but now fires independently per track. 2-week sprint, Mon/Wed/Thu rhythm, issue-level DoD, and closure ritual preserved. |
+| 24-07-2026 | Karim Abdulkin | Rev 2: aligned session protocol and closure ritual with P-01/P-02 findings; added QA-VAL references. |
+| March 2026 | Karim Abdulkin | Rev 2 initial: hypothesis-driven cycle, closure ritual, new DoD. |


### PR DESCRIPTION
## Summary

- **strategic-planning-rev3.md** — replaces sequential P1→P2→P3 phases with four simultaneous tracks (A=H1/Aizat, B=H2/Ilnar, C=H3/Timur, D=Recruitment/Alina). Single hard dependency preserved: H3 final validation requires H2 backend ready. Convergence point is "all hypotheses closed" rather than "P3 validated".
- **tactical-planning-rev3.md** — restructures the sprint for parallel tracks: Monday planning per track, Wednesday sync 15 min per track (full integration review every 2nd sprint), Thursday shows all three tracks to Denis simultaneously. Adds sprint-level DoD: every track must advance or explicitly name a blocker.

Preserved from Rev 2: 2-week sprint, Mon/Wed/Thu rhythm, issue-level DoD, hypothesis closure ritual, refutation handling.

## Test plan

- [x] Both files appear in the Jekyll nav under their respective parent sections (Strategic Planning / Tactical Planning → Current — Startup Proposal)
- [x] `docs-quality` CI check passes (markdownlint clean)
- [x] Frontmatter `nav_order: 3` does not collide with existing rev1/rev2 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RL3QbEZPPm9nWLS4WANQb7